### PR TITLE
chore(v0.0.4): Prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
 ## 0.0.3
 
 - Fixed an issue with the final coverage percentage calculation
+
+## 0.0.4
+
+- Flag `--excluded-paths` was added in order to exclude folders/files from coverage 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ $ cover check --min-coverage 80
 # Check code coverage without display files
 $ cover check --no-display-files
 
+# Check code coverage excluding some paths
+$ cover check --excluded-paths "/folder1, /folder2, file.txt"
+
 # Show current version
 $ cover --version
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cover
 description: The easy way to check your code coverage.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/aosorio-avilez/cover
 
 environment:


### PR DESCRIPTION
### Release v0.0.4

- Flag `--excluded-paths` was added in order to exclude folders/files from coverage 

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash
