### PR TITLE
🛡️ Sentinel: Fix Exception Leakage in CLI Runner

### DIFF
--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -72,6 +72,9 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
     } on PathNotFoundException catch (e) {
       printError(e.osError?.message ?? e.message);
       return ExitCode.osFile.code;
+    } on FileSystemException catch (e) {
+      printError(e.osError?.message ?? e.message);
+      return ExitCode.osFile.code;
     } on FileMustBeProvided catch (e) {
       printError(e.errMsg());
       return ExitCode.osFile.code;

--- a/test/file_system_exception_test.dart
+++ b/test/file_system_exception_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:cover/src/cover_command_runner.dart';
+import 'package:cover/src/models/exit_code.dart';
+import 'package:cover/src/services/coverage_service.dart';
+import 'package:dart_console/dart_console.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'mocks/console_mock.dart';
+
+void main() {
+  late Console console;
+  late CoverCommandRunner runner;
+  late Directory tempDir;
+
+  setUpAll(() {
+    registerFallbackValue(Table());
+  });
+
+  setUp(() async {
+    console = ConsoleMock();
+    tempDir = await Directory.systemTemp.createTemp('cover_crash_test');
+    final service = CoverageService(currentDirectory: tempDir);
+    runner = CoverCommandRunner(console: console, service: service);
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  test('FileSystemException Handling: verify FileSystemException is caught and handled gracefully', () async {
+    // Passing '.' (current directory) as path.
+    // This should cause FileSystemException: Is a directory.
+    // We expect it to be caught and return ExitCode.osFile.code.
+    // But currently it crashes.
+
+    // We use try-catch to assert the crash if it happens, or check exit code if fixed.
+    try {
+      final exitCode = await runner.run(['check', '--path', '.']);
+      expect(exitCode, ExitCode.osFile.code);
+
+      // Verify error message is printed
+      final captured = verify(() => console.writeErrorLine(captureAny())).captured;
+      expect(captured.isNotEmpty, isTrue);
+      expect(captured.first, contains('Is a directory'));
+
+    } catch (e) {
+      // If it crashes, it throws.
+      expect(e, isA<FileSystemException>());
+      // Fail the test explicitly to show it crashes (reproduction)
+      fail('Crashed with FileSystemException: $e');
+    }
+  });
+}


### PR DESCRIPTION
This PR addresses a medium-severity security issue (Exception Leakage). 
When `cover check` is run with a path that is a directory (e.g. `cover check --path .`), it previously crashed with an unhandled `FileSystemException` (Is a directory), exposing a stack trace with internal file paths.

Changes:
- Modified `lib/src/cover_command_runner.dart` to catch `FileSystemException` generally, print the error message (without path if possible, via `osError`), and return `ExitCode.osFile`.
- Added a regression test `test/file_system_exception_test.dart` that reproduces the issue and verifies the graceful exit.


---
*PR created automatically by Jules for task [14638021858029889814](https://jules.google.com/task/14638021858029889814) started by @aosorio-avilez*