### PR TITLE
refactor: Fix Exception Leakage in CLI Runner

### DIFF
--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -72,6 +72,9 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
     } on PathNotFoundException catch (e) {
       printError(e.osError?.message ?? e.message);
       return ExitCode.osFile.code;
+    } on FileSystemException catch (e) {
+      printError(e.message);
+      return ExitCode.osFile.code;
     } on FileMustBeProvided catch (e) {
       printError(e.errMsg());
       return ExitCode.osFile.code;

--- a/test/exception_leak_test.dart
+++ b/test/exception_leak_test.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:cover/src/cover_command_runner.dart';
+import 'package:cover/src/models/exit_code.dart';
+import 'package:cover/src/services/coverage_service.dart';
+import 'package:dart_console/dart_console.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'mocks/console_mock.dart';
+
+class MockCoverageService extends Mock implements CoverageService {}
+
+void main() {
+  late Console console;
+  late CoverCommandRunner runner;
+  late CoverageService service;
+
+  setUp(() {
+    console = ConsoleMock();
+    service = MockCoverageService();
+    runner = CoverCommandRunner(console: console, service: service);
+  });
+
+  test('Exception Leakage: should catch FileSystemException and exit gracefully',
+      () async {
+    // Arrange
+    when(() => service.checkCoverage(
+          filePath: any(named: 'filePath'),
+          minCoverage: any(named: 'minCoverage'),
+          excludePaths: any(named: 'excludePaths'),
+        )).thenThrow(
+      const FileSystemException('Access denied', 'coverage/lcov.info'),
+    );
+
+    // Act
+    // If not caught, this will throw and fail the test
+    final exitCode = await runner.run(['check']);
+
+    // Assert
+    expect(exitCode, ExitCode.osFile.code);
+    verify(() => console.writeErrorLine(any(that: contains('Access denied'))))
+        .called(1);
+  });
+}

--- a/test/exception_leak_test.dart
+++ b/test/exception_leak_test.dart
@@ -22,14 +22,17 @@ void main() {
     runner = CoverCommandRunner(console: console, service: service);
   });
 
-  test('Exception Leakage: should catch FileSystemException and exit gracefully',
+  test(
+      'Exception Leakage: should catch FileSystemException and exit gracefully',
       () async {
     // Arrange
-    when(() => service.checkCoverage(
-          filePath: any(named: 'filePath'),
-          minCoverage: any(named: 'minCoverage'),
-          excludePaths: any(named: 'excludePaths'),
-        )).thenThrow(
+    when(
+      () => service.checkCoverage(
+        filePath: any(named: 'filePath'),
+        minCoverage: any(named: 'minCoverage'),
+        excludePaths: any(named: 'excludePaths'),
+      ),
+    ).thenThrow(
       const FileSystemException('Access denied', 'coverage/lcov.info'),
     );
 


### PR DESCRIPTION
Prevents `FileSystemException` (e.g. Access Denied) from crashing the CLI and leaking stack traces. This ensures a graceful exit with `ExitCode.osFile`.

Includes a regression test case `test/exception_leak_test.dart`.

---
*PR created automatically by Jules for task [2923789044271395884](https://jules.google.com/task/2923789044271395884) started by @aosorio-avilez*