### PR TITLE
refactor: Fix exception leakage in coverage parsing

### DIFF
--- a/lib/src/services/coverage_service.dart
+++ b/lib/src/services/coverage_service.dart
@@ -61,7 +61,7 @@ class CoverageService {
     try {
       files = await Parser.parse(filePath);
     } catch (e) {
-      throw FormatException('Failed to parse coverage file: ${e.toString()}');
+      throw FormatException('Failed to parse coverage file: $e');
     }
 
     // Optimization: Filter out empty strings to avoid matching all files and

--- a/lib/src/services/coverage_service.dart
+++ b/lib/src/services/coverage_service.dart
@@ -57,7 +57,12 @@ class CoverageService {
     List<String> excludedPaths,
   ) async {
     // Note: filePath is now expected to be a validated, absolute path.
-    final files = await Parser.parse(filePath);
+    List<Record> files;
+    try {
+      files = await Parser.parse(filePath);
+    } catch (e) {
+      throw FormatException('Failed to parse coverage file: ${e.toString()}');
+    }
 
     // Optimization: Filter out empty strings to avoid matching all files and
     // ensure correctness.

--- a/test/security_exception_leak_test.dart
+++ b/test/security_exception_leak_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:cover/src/cover_command_runner.dart';
 import 'package:cover/src/models/exit_code.dart';
 import 'package:dart_console/dart_console.dart';
@@ -24,14 +25,14 @@ void main() {
       expect(exitCode, equals(ExitCode.usage.code));
 
       // Verify error message was printed
-      final captured = verify(() => console.writeErrorLine(captureAny())).captured;
+      final captured =
+          verify(() => console.writeErrorLine(captureAny())).captured;
       final message = captured.first as String;
 
       // Verify the message indicates a parsing failure and NOT a raw internal error
       expect(message, contains('Failed to parse coverage file'));
-
     } finally {
-      if (await file.exists()) await file.delete();
+      if (file.existsSync()) await file.delete();
     }
   });
 }

--- a/test/security_exception_leak_test.dart
+++ b/test/security_exception_leak_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'package:cover/src/cover_command_runner.dart';
+import 'package:cover/src/models/exit_code.dart';
+import 'package:dart_console/dart_console.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockConsole extends Mock implements Console {}
+
+void main() {
+  test('Gracefully handle malformed LCOV file without crashing', () async {
+    final console = MockConsole();
+    final runner = CoverCommandRunner(console: console);
+
+    // Create a garbage file that triggers StateError in lcov_parser
+    final file = File('malformed.lcov');
+    await file.writeAsString('GARBAGE CONTENT');
+
+    try {
+      // This should NOT throw an exception. It should catch it internally and return an exit code.
+      final exitCode = await runner.run(['check', '--path', 'malformed.lcov']);
+
+      // Verify it returned a failure code (likely usage error mapped from FormatException)
+      expect(exitCode, equals(ExitCode.usage.code));
+
+      // Verify error message was printed
+      final captured = verify(() => console.writeErrorLine(captureAny())).captured;
+      final message = captured.first as String;
+
+      // Verify the message indicates a parsing failure and NOT a raw internal error
+      expect(message, contains('Failed to parse coverage file'));
+
+    } finally {
+      if (await file.exists()) await file.delete();
+    }
+  });
+}


### PR DESCRIPTION
Prevents stack trace leakage when `lcov_parser` encounters invalid input. Instead of crashing with an unhandled `StateError`, the tool now prints a user-friendly error message. This improves security by hiding internal implementation details and paths from the user.

---
*PR created automatically by Jules for task [16530681596684835896](https://jules.google.com/task/16530681596684835896) started by @aosorio-avilez*