### PR TITLE
fix(commands): enhance robustness with input validation and global error handling

### DIFF
--- a/example/melos_cover_example.iml
+++ b/example/melos_cover_example.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -91,9 +91,23 @@ class CheckCoverageCommand extends Command<int> {
   }
 
   double getMinCoverageArgument() {
-    final minCoverage =
-        globalResults?[minCoverageArgumentName] as String? ?? '';
-    return double.tryParse(minCoverage) ?? defaultMinCoverage;
+    final minCoverageArg = globalResults?[minCoverageArgumentName] as String?;
+
+    if (minCoverageArg == null || minCoverageArg.isEmpty) {
+      return defaultMinCoverage;
+    }
+
+    final minCoverage = double.tryParse(minCoverageArg);
+
+    if (minCoverage == null || minCoverage < 0 || minCoverage > 100) {
+      throw UsageException(
+        'Invalid value for --$minCoverageArgumentName. '
+        'Expected a number between 0 and 100.',
+        '--$minCoverageArgumentName $minCoverageArg',
+      );
+    }
+
+    return minCoverage;
   }
 
   String getPathArgument() {

--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -102,7 +102,7 @@ class CheckCoverageCommand extends Command<int> {
     if (minCoverage == null || minCoverage < 0 || minCoverage > 100) {
       throw UsageException(
         'Invalid value for --$minCoverageArgumentName. '
-        'Expected a number between 0 and 100.',
+            'Expected a number between 0 and 100.',
         '--$minCoverageArgumentName $minCoverageArg',
       );
     }

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -78,6 +78,9 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
     } on FileMustBeProvided catch (e) {
       printError(e.errMsg());
       return ExitCode.osFile.code;
+    } catch (e) {
+      _console.writeErrorLine('An unexpected error occurred: $e');
+      return ExitCode.software.code;
     }
   }
 
@@ -100,15 +103,21 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
   }
 
   Future<String> getVersion() async {
-    final packageUri = Uri.parse('package:cover/');
-    final packagePath = await Isolate.resolvePackageUri(packageUri);
-    final pubspecPath = packagePath?.resolve('../pubspec.yaml');
+    try {
+      final packageUri = Uri.parse('package:cover/');
+      final packagePath = await Isolate.resolvePackageUri(packageUri);
+      if (packagePath == null) return 'unknown';
 
-    if (pubspecPath != null) {
-      final fileContent = await File.fromUri(pubspecPath).readAsString();
+      final pubspecPath = packagePath.resolve('../pubspec.yaml');
+      final pubspecFile = File.fromUri(pubspecPath);
+
+      if (!await pubspecFile.exists()) return 'unknown';
+
+      final fileContent = await pubspecFile.readAsString();
       final pubspec = Pubspec.parse(fileContent);
-      return pubspec.version!.toString();
+      return pubspec.version?.toString() ?? 'unknown';
+    } catch (_) {
+      return 'unknown';
     }
-    return 'unknown';
   }
 }

--- a/lib/src/models/exit_code.dart
+++ b/lib/src/models/exit_code.dart
@@ -2,6 +2,8 @@ enum ExitCode {
   success(code: 0, message: 'success'),
   fail(code: 1, message: 'fail'),
   usage(code: 64, message: 'usage'),
+  unavailable(code: 69, message: 'unavailable'),
+  software(code: 70, message: 'software'),
   osFile(code: 72, message: 'osFile');
 
   const ExitCode({required this.code, required this.message});

--- a/test/src/robustness_test.dart
+++ b/test/src/robustness_test.dart
@@ -17,27 +17,37 @@ void main() {
   });
 
   group('Robustness Tests', () {
-    test('verify check coverage command fails with invalid min-coverage (too high)', () async {
+    test(
+        'verify check coverage command fails with invalid min-coverage (too high)',
+        () async {
       final exitCode = await runner.run(['check', '--min-coverage', '101']);
       expect(exitCode, ExitCode.usage.code);
-      verify(() => console.writeErrorLine(contains('Expected a number between 0 and 100'))).called(1);
+      verify(() => console.writeErrorLine(
+          contains('Expected a number between 0 and 100'))).called(1);
     });
 
-    test('verify check coverage command fails with invalid min-coverage (too low)', () async {
+    test(
+        'verify check coverage command fails with invalid min-coverage (too low)',
+        () async {
       final exitCode = await runner.run(['check', '--min-coverage', '-1']);
       expect(exitCode, ExitCode.usage.code);
-      verify(() => console.writeErrorLine(contains('Expected a number between 0 and 100'))).called(1);
+      verify(() => console.writeErrorLine(
+          contains('Expected a number between 0 and 100'))).called(1);
     });
 
-    test('verify check coverage command fails with invalid min-coverage (not a number)', () async {
+    test(
+        'verify check coverage command fails with invalid min-coverage (not a number)',
+        () async {
       final exitCode = await runner.run(['check', '--min-coverage', 'abc']);
       expect(exitCode, ExitCode.usage.code);
-      verify(() => console.writeErrorLine(contains('Expected a number between 0 and 100'))).called(1);
+      verify(() => console.writeErrorLine(
+          contains('Expected a number between 0 and 100'))).called(1);
     });
 
     test('verify global exception handler catches unexpected errors', () async {
       final service = CoverageServiceMock();
-      final runnerWithMock = CoverCommandRunner(console: console, service: service);
+      final runnerWithMock =
+          CoverCommandRunner(console: console, service: service);
 
       when(() => service.checkCoverage(
             filePath: any(named: 'filePath'),
@@ -48,7 +58,9 @@ void main() {
       final exitCode = await runnerWithMock.run(['check']);
 
       expect(exitCode, ExitCode.software.code);
-      verify(() => console.writeErrorLine(contains('An unexpected error occurred: Bad state: Unexpected state'))).called(1);
+      verify(() => console.writeErrorLine(contains(
+              'An unexpected error occurred: Bad state: Unexpected state')))
+          .called(1);
     });
   });
 }

--- a/test/src/robustness_test.dart
+++ b/test/src/robustness_test.dart
@@ -1,0 +1,54 @@
+import 'package:cover/src/cover_command_runner.dart';
+import 'package:cover/src/models/exit_code.dart';
+import 'package:dart_console/dart_console.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../mocks/console_mock.dart';
+import '../mocks/coverage_service_mock.dart';
+
+void main() {
+  late Console console;
+  late CoverCommandRunner runner;
+
+  setUp(() {
+    console = ConsoleMock();
+    runner = CoverCommandRunner(console: console);
+  });
+
+  group('Robustness Tests', () {
+    test('verify check coverage command fails with invalid min-coverage (too high)', () async {
+      final exitCode = await runner.run(['check', '--min-coverage', '101']);
+      expect(exitCode, ExitCode.usage.code);
+      verify(() => console.writeErrorLine(contains('Expected a number between 0 and 100'))).called(1);
+    });
+
+    test('verify check coverage command fails with invalid min-coverage (too low)', () async {
+      final exitCode = await runner.run(['check', '--min-coverage', '-1']);
+      expect(exitCode, ExitCode.usage.code);
+      verify(() => console.writeErrorLine(contains('Expected a number between 0 and 100'))).called(1);
+    });
+
+    test('verify check coverage command fails with invalid min-coverage (not a number)', () async {
+      final exitCode = await runner.run(['check', '--min-coverage', 'abc']);
+      expect(exitCode, ExitCode.usage.code);
+      verify(() => console.writeErrorLine(contains('Expected a number between 0 and 100'))).called(1);
+    });
+
+    test('verify global exception handler catches unexpected errors', () async {
+      final service = CoverageServiceMock();
+      final runnerWithMock = CoverCommandRunner(console: console, service: service);
+
+      when(() => service.checkCoverage(
+            filePath: any(named: 'filePath'),
+            minCoverage: any(named: 'minCoverage'),
+            excludePaths: any(named: 'excludePaths'),
+          )).thenThrow(StateError('Unexpected state'));
+
+      final exitCode = await runnerWithMock.run(['check']);
+
+      expect(exitCode, ExitCode.software.code);
+      verify(() => console.writeErrorLine(contains('An unexpected error occurred: Bad state: Unexpected state'))).called(1);
+    });
+  });
+}

--- a/test/src/robustness_test.dart
+++ b/test/src/robustness_test.dart
@@ -22,8 +22,11 @@ void main() {
         () async {
       final exitCode = await runner.run(['check', '--min-coverage', '101']);
       expect(exitCode, ExitCode.usage.code);
-      verify(() => console.writeErrorLine(
-          contains('Expected a number between 0 and 100'))).called(1);
+      verify(
+        () => console.writeErrorLine(
+          contains('Expected a number between 0 and 100'),
+        ),
+      ).called(1);
     });
 
     test(
@@ -31,8 +34,11 @@ void main() {
         () async {
       final exitCode = await runner.run(['check', '--min-coverage', '-1']);
       expect(exitCode, ExitCode.usage.code);
-      verify(() => console.writeErrorLine(
-          contains('Expected a number between 0 and 100'))).called(1);
+      verify(
+        () => console.writeErrorLine(
+          contains('Expected a number between 0 and 100'),
+        ),
+      ).called(1);
     });
 
     test(
@@ -40,8 +46,11 @@ void main() {
         () async {
       final exitCode = await runner.run(['check', '--min-coverage', 'abc']);
       expect(exitCode, ExitCode.usage.code);
-      verify(() => console.writeErrorLine(
-          contains('Expected a number between 0 and 100'))).called(1);
+      verify(
+        () => console.writeErrorLine(
+          contains('Expected a number between 0 and 100'),
+        ),
+      ).called(1);
     });
 
     test('verify global exception handler catches unexpected errors', () async {
@@ -49,18 +58,24 @@ void main() {
       final runnerWithMock =
           CoverCommandRunner(console: console, service: service);
 
-      when(() => service.checkCoverage(
-            filePath: any(named: 'filePath'),
-            minCoverage: any(named: 'minCoverage'),
-            excludePaths: any(named: 'excludePaths'),
-          )).thenThrow(StateError('Unexpected state'));
+      when(
+        () => service.checkCoverage(
+          filePath: any(named: 'filePath'),
+          minCoverage: any(named: 'minCoverage'),
+          excludePaths: any(named: 'excludePaths'),
+        ),
+      ).thenThrow(StateError('Unexpected state'));
 
       final exitCode = await runnerWithMock.run(['check']);
 
       expect(exitCode, ExitCode.software.code);
-      verify(() => console.writeErrorLine(contains(
-              'An unexpected error occurred: Bad state: Unexpected state')))
-          .called(1);
+      verify(
+        () => console.writeErrorLine(
+          contains(
+            'An unexpected error occurred: Bad state: Unexpected state',
+          ),
+        ),
+      ).called(1);
     });
   });
 }


### PR DESCRIPTION
This PR enhances the robustness and security of the `cover` CLI tool by implementing stricter input validation and a global exception safety net. These changes ensure the CLI fails gracefully with user-friendly messages instead of crashing with raw stack traces.

### Key Changes:
- **Input Validation**: Added strict validation for the `--min-coverage` argument. It now ensures the value is a number between 0 and 100, throwing a clear `UsageException` if the input is invalid.
- **Global Error Handling**: Introduced a catch-all exception block in `CoverCommandRunner`. This prevents unexpected internal errors from leaking stack traces to the user and ensures the CLI exits with a standard `ExitCode.software` (70).
- **Robust Versioning**: Refactored `getVersion` to safely handle missing or malformed `pubspec.yaml` files, preventing crashes during version checks.
- **Expanded Exit Codes**: Added `unavailable` (69) and `software` (70) to the `ExitCode` model for better error categorization.
- **Robustness Tests**: Added new unit tests in `test/src/robustness_test.dart` to verify these enhancements.

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [x] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash

---
*PR created automatically by Jules for task [7084570917492663675](https://jules.google.com/task/7084570917492663675) started by @aosorio-avilez*