### PR TITLE
fix(commands): improve robustness of min-coverage validation and output sanitization

### DIFF
--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -99,7 +99,10 @@ class CheckCoverageCommand extends Command<int> {
 
     final minCoverage = double.tryParse(minCoverageArg);
 
-    if (minCoverage == null || minCoverage < 0 || minCoverage > 100) {
+    if (minCoverage == null ||
+        minCoverage.isNaN ||
+        minCoverage < 0 ||
+        minCoverage > 100) {
       throw UsageException(
         'Invalid value for --$minCoverageArgumentName. '
             'Expected a number between 0 and 100.',

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -2,7 +2,7 @@ import 'package:cover/src/extensions/double_extension.dart';
 import 'package:lcov_parser/lcov_parser.dart';
 
 final _ansiAndControlRegExp = RegExp(
-  r'\x1B\[[0-?]*[ -/]*[@-~]|[\x00-\x1F\x7F]',
+  r'\x1B\[[0-?]*[ -/]*[@-~]|[\x00-\x1F\x7F\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]',
 );
 
 extension RecordExtension on Record {
@@ -37,7 +37,14 @@ bool _hasAnsiOrControlChars(String s) {
   for (var i = 0; i < s.length; i++) {
     final code = s.codeUnitAt(i);
     // 0x00-0x1F (control chars including \x1B) and 0x7F (DEL)
-    if (code <= 0x1F || code == 0x7F) {
+    // Also include Unicode Bidi control characters.
+    if (code <= 0x1F ||
+        code == 0x7F ||
+        code == 0x061C ||
+        code == 0x200E ||
+        code == 0x200F ||
+        (code >= 0x202A && code <= 0x202E) ||
+        (code >= 0x2066 && code <= 0x2069)) {
       return true;
     }
   }

--- a/melos_cover.iml
+++ b/melos_cover.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/test/src/extensions/record_extension_test.dart
+++ b/test/src/extensions/record_extension_test.dart
@@ -53,6 +53,24 @@ void main() {
 
       await file.delete();
     });
+
+    test('toRow sanitizes Bidi control characters from filename', () async {
+      final file = File('test_bidi.info');
+      // Using U+202E (Right-to-Left Override)
+      await file.writeAsString(
+        'SF:file.dart\u202Ecod.exe\nDA:1,1\nLF:1\nLH:1\nend_of_record',
+      );
+
+      final records = await Parser.parse(file.path);
+      final record = records.first;
+      final row = record.toRow();
+
+      final fileNameInRow = row[0].toString();
+      expect(fileNameInRow, contains('file.dartcod.exe'));
+      expect(fileNameInRow, isNot(contains('\u202E')));
+
+      await file.delete();
+    });
   });
 
   group('RecordListExtension', () {

--- a/test/src/robustness_test.dart
+++ b/test/src/robustness_test.dart
@@ -53,8 +53,7 @@ void main() {
       ).called(1);
     });
 
-    test(
-        'verify check coverage command fails with invalid min-coverage (NaN)',
+    test('verify check coverage command fails with invalid min-coverage (NaN)',
         () async {
       final exitCode = await runner.run(['check', '--min-coverage', 'NaN']);
       expect(exitCode, ExitCode.usage.code);

--- a/test/src/robustness_test.dart
+++ b/test/src/robustness_test.dart
@@ -53,6 +53,18 @@ void main() {
       ).called(1);
     });
 
+    test(
+        'verify check coverage command fails with invalid min-coverage (NaN)',
+        () async {
+      final exitCode = await runner.run(['check', '--min-coverage', 'NaN']);
+      expect(exitCode, ExitCode.usage.code);
+      verify(
+        () => console.writeErrorLine(
+          contains('Expected a number between 0 and 100'),
+        ),
+      ).called(1);
+    });
+
     test('verify global exception handler catches unexpected errors', () async {
       final service = CoverageServiceMock();
       final runnerWithMock =


### PR DESCRIPTION
### Summary
This PR improves the robustness of the `cover` CLI by addressing two key areas: input validation and terminal output safety.

### Changes
- **Improved Input Validation**: The `--min-coverage` argument now explicitly rejects `NaN` (Not-a-Number) values. Previously, `NaN` could bypass range checks, potentially leading to undefined behavior during coverage calculations.
- **Enhanced Output Sanitization**: Filenames displayed in the coverage table are now sanitized to remove Unicode Bidirectional (Bidi) control characters (e.g., Right-to-Left Override). This prevents "Trojan Source" style attacks where malicious LCOV files could use these characters to spoof filenames or hide extensions in the terminal output.

### Impact
- Users are protected from deceptive terminal output when processing untrusted coverage files.
- The CLI provides clearer error messages when invalid numeric values are provided for coverage thresholds.

---
*PR created automatically by Jules for task [7368088310781772907](https://jules.google.com/task/7368088310781772907) started by @aosorio-avilez*