### PR TITLE
Enhance filename output sanitization with Bidi character stripping

### DIFF
--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -2,7 +2,7 @@ import 'package:cover/src/extensions/double_extension.dart';
 import 'package:lcov_parser/lcov_parser.dart';
 
 final _ansiAndControlRegExp = RegExp(
-  r'\x1B\[[0-?]*[ -/]*[@-~]|[\x00-\x1F\x7F]',
+  r'\x1B\[[0-?]*[ -/]*[@-~]|[\x00-\x1F\x7F]|\u061C|[\u200E\u200F]|[\u202A-\u202E]|[\u2066-\u2069]',
 );
 
 extension RecordExtension on Record {
@@ -36,8 +36,15 @@ extension RecordExtension on Record {
 bool _hasAnsiOrControlChars(String s) {
   for (var i = 0; i < s.length; i++) {
     final code = s.codeUnitAt(i);
-    // 0x00-0x1F (control chars including \x1B) and 0x7F (DEL)
-    if (code <= 0x1F || code == 0x7F) {
+    // 0x00-0x1F (control chars including \x1B), 0x7F (DEL),
+    // and Unicode Bidi control characters.
+    if (code <= 0x1F ||
+        code == 0x7F ||
+        code == 0x061C ||
+        code == 0x200E ||
+        code == 0x200F ||
+        (code >= 0x202A && code <= 0x202E) ||
+        (code >= 0x2066 && code <= 0x2069)) {
       return true;
     }
   }


### PR DESCRIPTION
The filename sanitization logic in `RecordExtension` has been enhanced to protect against Unicode Bidirectional (Bidi) control character attacks. Previously, it only targeted common ANSI escape sequences and standard ASCII control characters. 

The update includes:
1.  **Regex Expansion**: `_ansiAndControlRegExp` now includes a comprehensive set of Bidi control characters (`U+061C`, `U+200E`, `U+200F`, `U+202A`-`U+202E`, and `U+2066`-`U+2069`).
2.  **Optimization Sync**: The `_hasAnsiOrControlChars` function, which provides a fast-path check to avoid regex overhead on clean strings, was updated to include the same Bidi character ranges.

This ensures that the output sanitization correctly handles "Trojan Source" style attacks where Bidi overrides are used to trick users about file extensions or content in the terminal. Verification was performed with a standalone Dart script to confirm both ANSI and Bidi characters are correctly identified and stripped.

---
*PR created automatically by Jules for task [7962860856661012293](https://jules.google.com/task/7962860856661012293) started by @aosorio-avilez*