### PR TITLE
feat(commands): add --json flag for machine-readable coverage output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0 (Unreleased)
+
+- **Feat**: Added `--json` (abbr `-j`) flag to `check` command for machine-readable coverage output.
+
 ## 0.3.0
 
 - **Feat**: Integrated **Melos** as a workspace manager using **Dart Workspaces**.

--- a/example/bin/cover_example.dart
+++ b/example/bin/cover_example.dart
@@ -7,7 +7,7 @@ void main() async {
   final runner = CoverCommandRunner();
 
   // Simulate command line arguments
-  final args = ['check', '--path', 'params/lcov.info'];
+  final args = ['check', '--path', 'params/lcov.info', '--json'];
 
   // Run the command
   final exitCode = await runner.run(args);

--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:args/command_runner.dart';
+import 'package:cover/src/cover_command_runner.dart';
 import 'package:cover/src/extensions/double_extension.dart';
 import 'package:cover/src/extensions/record_extension.dart';
 import 'package:cover/src/models/exit_code.dart';
@@ -46,6 +48,7 @@ class CheckCoverageCommand extends Command<int> {
     final minCoverage = getMinCoverageArgument();
     final displayFiles = getDisplayFilesArgument();
     final excludePaths = getExcludePathsArgument();
+    final isJson = getJsonArgument();
 
     try {
       final result = await _service.checkCoverage(
@@ -54,22 +57,27 @@ class CheckCoverageCommand extends Command<int> {
         excludePaths: excludePaths,
       );
 
-      final table = buildCoverageFileTable();
       final currentCoverage = result.coverage;
-      final color = currentCoverage.getCoverageColorAnsi();
 
-      if (displayFiles) {
-        for (final record in result.files) {
-          table.insertRow(record.toRow());
+      if (isJson) {
+        console.writeLine(jsonEncode(result.toJson()));
+      } else {
+        final table = buildCoverageFileTable();
+        final color = currentCoverage.getCoverageColorAnsi();
+
+        if (displayFiles) {
+          for (final record in result.files) {
+            table.insertRow(record.toRow());
+          }
+
+          console.write(table);
         }
 
-        console.write(table);
+        console
+          ..writeLine('Minimun coverage: $greenColor$minCoverage%')
+          ..resetColorAttributes()
+          ..writeLine('Current coverage: $color$currentCoverage%');
       }
-
-      console
-        ..writeLine('Minimun coverage: $greenColor$minCoverage%')
-        ..resetColorAttributes()
-        ..writeLine('Current coverage: $color$currentCoverage%');
 
       return currentCoverage >= minCoverage
           ? ExitCode.success.code
@@ -132,5 +140,9 @@ class CheckCoverageCommand extends Command<int> {
     }
 
     return excludePathsString.split(',').map((e) => e.trim()).toList();
+  }
+
+  bool getJsonArgument() {
+    return globalResults?[jsonFlag] as bool? ?? false;
   }
 }

--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -60,7 +60,13 @@ class CheckCoverageCommand extends Command<int> {
       final currentCoverage = result.coverage;
 
       if (isJson) {
-        console.writeLine(jsonEncode(result.toJson()));
+        final jsonOutput = const JsonEncoder.withIndent('  ').convert(
+          result.toJson(
+            minCoverage: minCoverage,
+            excludePaths: excludePaths,
+          ),
+        );
+        console.writeLine(jsonOutput);
       } else {
         final table = buildCoverageFileTable();
         final color = currentCoverage.getCoverageColorAnsi();

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -15,6 +15,8 @@ const executableName = 'cover';
 const description = 'The easy way to check code coverage';
 const versionFlag = 'version';
 const versionDescription = 'Print the current version.';
+const jsonFlag = 'json';
+const jsonDescription = 'Output the result in JSON format.';
 
 class CoverCommandRunner extends CompletionCommandRunner<int> {
   CoverCommandRunner({Console? console, CoverageService? service})
@@ -27,6 +29,12 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
         abbr: 'v',
         negatable: false,
         help: versionDescription,
+      )
+      ..addFlag(
+        jsonFlag,
+        abbr: 'j',
+        negatable: false,
+        help: jsonDescription,
       )
       ..addFlag(
         displayFilesArgumentName,

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -16,6 +16,15 @@ extension RecordExtension on Record {
     return (coveragePercentage * 100).roundToDouble() / 100;
   }
 
+  Map<String, dynamic> toJson() {
+    return {
+      'file': file,
+      'coverage': coveragePercentage,
+      'found_lines': lines?.found ?? 0,
+      'hit_lines': lines?.hit ?? 0,
+    };
+  }
+
   List<Object> toRow() {
     final percentage = coveragePercentage;
     final color = percentage.getCoverageColorAnsi();

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -20,8 +20,8 @@ extension RecordExtension on Record {
     return {
       'file': file,
       'coverage': coveragePercentage,
-      'found_lines': lines?.found ?? 0,
-      'hit_lines': lines?.hit ?? 0,
+      'lines_found': lines?.found ?? 0,
+      'lines_hit': lines?.hit ?? 0,
     };
   }
 

--- a/lib/src/models/coverage_result.dart
+++ b/lib/src/models/coverage_result.dart
@@ -7,9 +7,17 @@ class CoverageResult {
   final double coverage;
   final List<Record> files;
 
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toJson({
+    required double minCoverage,
+    List<String> excludePaths = const [],
+  }) {
     return {
       'coverage': coverage,
+      'min_coverage': minCoverage,
+      'passed': coverage >= minCoverage,
+      'timestamp': DateTime.now().toIso8601String(),
+      'files_count': files.length,
+      'excluded_paths': excludePaths,
       'files': files.map((file) => file.toJson()).toList(),
     };
   }

--- a/lib/src/models/coverage_result.dart
+++ b/lib/src/models/coverage_result.dart
@@ -1,3 +1,4 @@
+import 'package:cover/src/extensions/record_extension.dart';
 import 'package:lcov_parser/lcov_parser.dart';
 
 class CoverageResult {
@@ -5,4 +6,11 @@ class CoverageResult {
 
   final double coverage;
   final List<Record> files;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'coverage': coverage,
+      'files': files.map((file) => file.toJson()).toList(),
+    };
+  }
 }

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:cover/src/commands/check_coverage_command.dart';
 import 'package:cover/src/cover_command_runner.dart';
 import 'package:cover/src/models/exit_code.dart';
@@ -115,6 +117,29 @@ void main() {
       verify(() => console.write(any())).called(1);
       verify(() => console.writeLine(any())).called(2);
       verify(() => console.resetColorAttributes()).called(1);
+    },
+  );
+
+  test(
+    'verify check coverage command return json with --json flag',
+    () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_complete.info',
+        '--json',
+      ]);
+
+      expect(exitCode, ExitCode.success.code);
+      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final jsonOutput = captured.first as String;
+      final decoded = jsonDecode(jsonOutput) as Map<String, dynamic>;
+
+      expect(decoded['coverage'], 100.0);
+      expect(decoded['files'], isA<List<dynamic>>());
+      expect((decoded['files'] as List<dynamic>).length, 17);
+      verifyNever(() => console.write(any()));
+      verifyNever(() => console.resetColorAttributes());
     },
   );
 }

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -136,8 +136,20 @@ void main() {
       final decoded = jsonDecode(jsonOutput) as Map<String, dynamic>;
 
       expect(decoded['coverage'], 100.0);
+      expect(decoded['min_coverage'], 100.0);
+      expect(decoded['passed'], isTrue);
+      expect(decoded['timestamp'], isA<String>());
+      expect(decoded['files_count'], 17);
       expect(decoded['files'], isA<List<dynamic>>());
       expect((decoded['files'] as List<dynamic>).length, 17);
+
+      final firstFile =
+          (decoded['files'] as List<dynamic>).first as Map<String, dynamic>;
+      expect(firstFile['file'], isA<String>());
+      expect(firstFile['coverage'], isA<num>());
+      expect(firstFile['lines_found'], isA<int>());
+      expect(firstFile['lines_hit'], isA<int>());
+
       verifyNever(() => console.write(any()));
       verifyNever(() => console.resetColorAttributes());
     },


### PR DESCRIPTION
This PR introduces a new `--json` (shorthand `-j`) flag to the `check` command. 

### Why this is useful:
In modern CI/CD pipelines, developers often need to parse coverage data programmatically to trigger custom notifications, generate specialized reports, or integrate with other DevOps tools. By providing a machine-readable JSON output, the `cover` tool becomes significantly more "pipeline-friendly" and versatile.

### Changes:
- Added a global `--json` flag to `CoverCommandRunner`.
- Implemented `toJson()` methods in `CoverageResult` and `RecordExtension` for structured data serialization.
- Updated `CheckCoverageCommand` to detect the flag and output encoded JSON instead of the human-readable table when requested.
- Added comprehensive unit tests to ensure correct JSON structure and respect for coverage thresholds.

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash

---
*PR created automatically by Jules for task [15781714996516716836](https://jules.google.com/task/15781714996516716836) started by @aosorio-avilez*