### PR TITLE
perf(parser): pre-compile generated files regex

### DIFF
--- a/lib/src/services/coverage_service.dart
+++ b/lib/src/services/coverage_service.dart
@@ -9,6 +9,14 @@ class CoverageService {
   CoverageService({Directory? currentDirectory})
       : _currentDirectory = currentDirectory ?? Directory.current;
 
+  static const _generatedPattern =
+      r'\.(g|freezed|mocks|template|reflectable|config|pigeon|gr|pb|graphql|mapper)\.dart$';
+
+  static final _generatedRegExp = RegExp(
+    _generatedPattern,
+    caseSensitive: false,
+  );
+
   final Directory _currentDirectory;
   Future<String>? _resolvedCurrentDirectoryPath;
 
@@ -82,18 +90,22 @@ class CoverageService {
       return files;
     }
 
-    // Optimization: Using a single RegExp with alternation is significantly
-    // faster than iterating through the list with String.contains for larger
-    // sets of excluded paths.
-    final patterns = validExcludedPaths.map(RegExp.escape).toList();
+    RegExp regExp;
 
-    if (excludeGenerated) {
-      patterns.add(
-        r'\.(g|freezed|mocks|template|reflectable|config|pigeon|gr|pb|graphql|mapper)\.dart$',
-      );
+    if (validExcludedPaths.isEmpty && excludeGenerated) {
+      regExp = _generatedRegExp;
+    } else {
+      // Optimization: Using a single RegExp with alternation is significantly
+      // faster than iterating through the list with String.contains for larger
+      // sets of excluded paths.
+      final patterns = validExcludedPaths.map(RegExp.escape).toList();
+
+      if (excludeGenerated) {
+        patterns.add(_generatedPattern);
+      }
+
+      regExp = RegExp(patterns.join('|'), caseSensitive: false);
     }
-
-    final regExp = RegExp(patterns.join('|'), caseSensitive: false);
 
     // Note: `files` is a fresh list from `Parser.parse`, so we can mutate it
     // safely.


### PR DESCRIPTION
This PR introduces a performance optimization to the `CoverageService` by pre-compiling the regular expression used for identifying generated files. 

### Changes:
- Defined `_generatedPattern` and `_generatedRegExp` as static members of `CoverageService` to avoid redundant string allocations and `RegExp` compilations during coverage filtering.
- Refactored `_parseCoverageFile` to maintain a single-pass filtering operation (using `retainWhere` only once) by combining user-defined exclusion patterns with the pre-compiled generated files pattern when necessary.

### Impact:
- Reduces CPU overhead and memory allocations during LCOV file filtering, especially for large projects with many records.
- Ensures consistent performance by avoiding repetitive regex compilation in a core service.

---
*PR created automatically by Jules for task [14729249041946464062](https://jules.google.com/task/14729249041946464062) started by @aosorio-avilez*