### PR TITLE
feat(commands): add --show-uncovered flag to display missing coverage line numbers

### DIFF
--- a/example/melos_cover_example.iml
+++ b/example/melos_cover_example.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -31,6 +31,10 @@ const defaultExcludePaths = '';
 const excludePathsHelp =
     'Specify paths separate by comma to exclude from coverage';
 
+const showUncoveredArgumentName = 'show-uncovered';
+const defaultShowUncovered = false;
+const showUncoveredHelp = 'Display uncovered line numbers';
+
 const commandDescription = 'Check code coverage';
 const commandName = 'check';
 
@@ -55,6 +59,7 @@ class CheckCoverageCommand extends Command<int> {
     final excludePaths = getExcludePathsArgument();
     final excludeGenerated = getExcludeGeneratedArgument();
     final isJson = getJsonArgument();
+    final showUncovered = getShowUncoveredArgument();
 
     final result = await _service.checkCoverage(
       filePath: filePath,
@@ -78,9 +83,9 @@ class CheckCoverageCommand extends Command<int> {
       final color = currentCoverage.getCoverageColorAnsi();
 
       if (displayFiles) {
-        final table = buildCoverageFileTable();
+        final table = buildCoverageFileTable(showUncovered: showUncovered);
         for (final record in result.files) {
-          table.insertRow(record.toRow());
+          table.insertRow(record.toRow(showUncovered: showUncovered));
         }
 
         console.write(table);
@@ -97,13 +102,21 @@ class CheckCoverageCommand extends Command<int> {
         : ExitCode.fail.code;
   }
 
-  Table buildCoverageFileTable() {
-    return Table()
+  Table buildCoverageFileTable({bool showUncovered = false}) {
+    final table = Table()
       ..insertColumn(header: 'File name')
       ..insertColumn(header: 'Found Lines', alignment: TextAlignment.center)
       ..insertColumn(header: 'Hit Lines', alignment: TextAlignment.center)
-      ..insertColumn(header: 'Coverage', alignment: TextAlignment.center)
-      ..borderColor = ConsoleColor.black;
+      ..insertColumn(header: 'Coverage', alignment: TextAlignment.center);
+
+    if (showUncovered) {
+      table.insertColumn(
+        header: 'Uncovered Lines',
+        alignment: TextAlignment.center,
+      );
+    }
+
+    return table..borderColor = ConsoleColor.black;
   }
 
   double getMinCoverageArgument() {
@@ -157,5 +170,10 @@ class CheckCoverageCommand extends Command<int> {
 
   bool getJsonArgument() {
     return globalResults?[jsonFlag] as bool? ?? false;
+  }
+
+  bool getShowUncoveredArgument() {
+    return globalResults?[showUncoveredArgumentName] as bool? ??
+        defaultShowUncovered;
   }
 }

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -63,6 +63,12 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
       ..addFlag(
         excludeGeneratedArgumentName,
         help: excludeGeneratedHelp,
+      )
+      ..addFlag(
+        showUncoveredArgumentName,
+        abbr: 'u',
+        help: showUncoveredHelp,
+        defaultsTo: defaultShowUncovered,
       );
 
     addCommand(CheckCoverageCommand(_console, service: coverageService));

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -6,6 +6,36 @@ final _ansiAndControlRegExp = RegExp(
 );
 
 extension RecordExtension on Record {
+  List<int> get uncoveredLines {
+    final details = lines?.details;
+    if (details == null) return [];
+    return details
+        .where((detail) => (detail.hit ?? 0) == 0)
+        .map((detail) => detail.line ?? 0)
+        .where((line) => line != 0)
+        .toList();
+  }
+
+  String _formatUncoveredLines(List<int> lines) {
+    if (lines.isEmpty) return '';
+    lines.sort();
+    final ranges = <String>[];
+    var start = lines[0];
+    var end = lines[0];
+
+    for (var i = 1; i < lines.length; i++) {
+      if (lines[i] == end + 1) {
+        end = lines[i];
+      } else {
+        ranges.add(start == end ? '$start' : '$start-$end');
+        start = lines[i];
+        end = lines[i];
+      }
+    }
+    ranges.add(start == end ? '$start' : '$start-$end');
+    return ranges.join(', ');
+  }
+
   double get coveragePercentage {
     final lines = this.lines;
     final linesHit = lines?.hit ?? 0;
@@ -22,10 +52,11 @@ extension RecordExtension on Record {
       'coverage': coveragePercentage,
       'lines_found': lines?.found ?? 0,
       'lines_hit': lines?.hit ?? 0,
+      'uncovered_lines': uncoveredLines,
     };
   }
 
-  List<Object> toRow() {
+  List<Object> toRow({bool showUncovered = false}) {
     final percentage = coveragePercentage;
     final color = percentage.getCoverageColorAnsi();
     final lines = this.lines;
@@ -42,12 +73,19 @@ extension RecordExtension on Record {
     final sanitizedFile = _hasAnsiOrControlChars(fileName)
         ? fileName.replaceAll(_ansiAndControlRegExp, '')
         : fileName;
-    return <Object>[
+
+    final row = <Object>[
       '$color$sanitizedFile',
       '$color${lines?.found}',
       '$color${lines?.hit}',
       formattedPercentage,
     ];
+
+    if (showUncovered) {
+      row.add('$color${_formatUncoveredLines(uncoveredLines)}');
+    }
+
+    return row;
   }
 }
 

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -201,4 +201,51 @@ void main() {
       verifyNever(() => console.resetColorAttributes());
     },
   );
+
+  test(
+    'verify check coverage command shows uncovered lines with --show-uncovered flag',
+    () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--show-uncovered',
+      ]);
+
+      expect(exitCode, ExitCode.fail.code);
+      final captured = verify(() => console.write(captureAny())).captured;
+      final table = captured.first as Table;
+      expect(table.columns, 5);
+
+      verify(() => console.writeLine(any(), any())).called(2);
+      verify(() => console.resetColorAttributes()).called(1);
+    },
+  );
+
+  test(
+    'verify check coverage command JSON includes uncovered_lines in files',
+    () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--json',
+      ]);
+
+      expect(exitCode, ExitCode.fail.code);
+      final captured =
+          verify(() => console.writeLine(captureAny(), any())).captured;
+      final jsonOutput = captured.first as String;
+      final decoded = jsonDecode(jsonOutput) as Map<String, dynamic>;
+
+      final files = decoded['files'] as List<dynamic>;
+      final apiFile = files.firstWhere(
+        (f) => f['file'] == 'lib/src/api/auth_api_impl.dart',
+      ) as Map<String, dynamic>;
+
+      expect(apiFile['uncovered_lines'], containsAll([20, 22]));
+      verifyNever(() => console.write(any()));
+      verifyNever(() => console.resetColorAttributes());
+    },
+  );
 }

--- a/test/src/extensions/record_extension_test.dart
+++ b/test/src/extensions/record_extension_test.dart
@@ -71,6 +71,56 @@ void main() {
 
       await file.delete();
     });
+
+    test('uncoveredLines returns correct line numbers', () async {
+      final file = File('test_uncovered.info');
+      await file.writeAsString(
+        'SF:test.dart\nDA:1,1\nDA:2,0\nDA:3,1\nDA:4,0\nLF:4\nLH:2\nend_of_record',
+      );
+
+      final records = await Parser.parse(file.path);
+      final record = records.first;
+
+      expect(record.uncoveredLines, [2, 4]);
+
+      await file.delete();
+    });
+
+    test('toRow includes uncovered lines when requested', () async {
+      final file = File('test_uncovered_row.info');
+      await file.writeAsString(
+        'SF:test.dart\nDA:1,0\nDA:2,0\nDA:3,0\nDA:5,0\nLF:4\nLH:0\nend_of_record',
+      );
+
+      final records = await Parser.parse(file.path);
+      final record = records.first;
+
+      // Without showUncovered
+      final rowDefault = record.toRow();
+      expect(rowDefault.length, 4);
+
+      // With showUncovered
+      final rowWithUncovered = record.toRow(showUncovered: true);
+      expect(rowWithUncovered.length, 5);
+      expect(rowWithUncovered[4].toString(), contains('1-3, 5'));
+
+      await file.delete();
+    });
+
+    test('toJson includes uncovered lines', () async {
+      final file = File('test_uncovered_json.info');
+      await file.writeAsString(
+        'SF:test.dart\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record',
+      );
+
+      final records = await Parser.parse(file.path);
+      final record = records.first;
+      final json = record.toJson();
+
+      expect(json['uncovered_lines'], [1]);
+
+      await file.delete();
+    });
   });
 
   group('RecordListExtension', () {

--- a/test/src/extensions/record_extension_test.dart
+++ b/test/src/extensions/record_extension_test.dart
@@ -72,6 +72,11 @@ void main() {
       await file.delete();
     });
 
+    test('uncoveredLines returns empty list if details are null', () {
+      final record = Record();
+      expect(record.uncoveredLines, isEmpty);
+    });
+
     test('uncoveredLines returns correct line numbers', () async {
       final file = File('test_uncovered.info');
       await file.writeAsString(
@@ -103,6 +108,30 @@ void main() {
       final rowWithUncovered = record.toRow(showUncovered: true);
       expect(rowWithUncovered.length, 5);
       expect(rowWithUncovered[4].toString(), contains('1-3, 5'));
+
+      await file.delete();
+    });
+
+    test('toRow handles showUncovered when there are no uncovered lines', () async {
+      final file = File('test_no_uncovered_row.info');
+      await file.writeAsString(
+        'SF:test.dart\nDA:1,1\nDA:2,1\nLF:2\nLH:2\nend_of_record',
+      );
+
+      final records = await Parser.parse(file.path);
+      final record = records.first;
+
+      expect(record.uncoveredLines, isEmpty);
+
+      final rowWithUncovered = record.toRow(showUncovered: true);
+      expect(rowWithUncovered.length, 5);
+      expect(
+        rowWithUncovered[4].toString().replaceAll(
+              RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]'),
+              '',
+            ),
+        isEmpty,
+      );
 
       await file.delete();
     });

--- a/test/src/extensions/record_extension_test.dart
+++ b/test/src/extensions/record_extension_test.dart
@@ -112,7 +112,8 @@ void main() {
       await file.delete();
     });
 
-    test('toRow handles showUncovered when there are no uncovered lines', () async {
+    test('toRow handles showUncovered when there are no uncovered lines',
+        () async {
       final file = File('test_no_uncovered_row.info');
       await file.writeAsString(
         'SF:test.dart\nDA:1,1\nDA:2,1\nLF:2\nLH:2\nend_of_record',


### PR DESCRIPTION
Added a new flag `--show-uncovered` (abbr `-u`) to the `check` command that displays the specific line numbers missing coverage. Uncovered lines are intelligently grouped into ranges (e.g., "1-3, 5") to maintain console readability. The JSON output was also updated to include `uncovered_lines` for each file, enhancing integration with CI/CD pipelines. This change follows the project's "Thin Command, Fat Service" architecture by encapsulating logic within extensions and services.

---
*PR created automatically by Jules for task [16014397123394662755](https://jules.google.com/task/16014397123394662755) started by @aosorio-avilez*