### PR TITLE
chore(release): prepare v0.4.0 release and fix test lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-## 0.4.0 (Unreleased)
+## 0.4.0
 
+- **Feat**: Added `--show-uncovered` flag to display missing coverage line numbers.
 - **Feat**: Added `--exclude-generated` flag to `check` command to ignore common generated files (e.g., `.g.dart`, `.freezed.dart`, `.mocks.dart`).
 - **Feat**: Added `--json` (abbr `-j`) flag to `check` command for machine-readable coverage output.
+- **Feat**: Added automated Pull Request reviewer workflow for AI agents.
+- **Perf**: Pre-compiled generated files regex for faster parsing.
+- **Perf**: Deferred table allocation in check coverage command.
+- **Perf**: Optimized coverage aggregation with indexed loop.
+- **Perf**: Optimized `Record` extension `toRow` with fast-path for 100% coverage.
+- **Refactor**: Consolidated agent guidelines and removed legacy `AGENTS.md`.
 
 ## 0.3.0
 

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -68,7 +68,6 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
         showUncoveredArgumentName,
         abbr: 'u',
         help: showUncoveredHelp,
-        defaultsTo: defaultShowUncovered,
       );
 
     addCommand(CheckCoverageCommand(_console, service: coverageService));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cover
 description: A simple and efficient tool for comprehensive code coverage analysis.
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/aosorio-avilez/cover
 
 environment:

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -238,10 +238,10 @@ void main() {
       final jsonOutput = captured.first as String;
       final decoded = jsonDecode(jsonOutput) as Map<String, dynamic>;
 
-      final files = decoded['files'] as List<dynamic>;
+      final files = List<Map<String, dynamic>>.from(decoded['files'] as List);
       final apiFile = files.firstWhere(
         (f) => f['file'] == 'lib/src/api/auth_api_impl.dart',
-      ) as Map<String, dynamic>;
+      );
 
       expect(apiFile['uncovered_lines'], containsAll([20, 22]));
       verifyNever(() => console.write(any()));


### PR DESCRIPTION
# Description
This PR prepares the `cover` package for the official **0.4.0** release. It properly consolidates all the recent additions—such as the `--show-uncovered`, `--exclude-generated`, and `--json` flags—along with various performance optimizations into the `CHANGELOG.md`. It also bumps the version in the `pubspec.yaml` file to match. 

Additionally, this PR resolves a minor static analysis warning caused by dynamic property access in the test suite and ensures all files are correctly formatted, guaranteeing a clean, green build prior to publishing to `pub.dev`.

Fixes: Preparation for version 0.4.0 release.

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [x] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Trash
