### PR TITLE
feat(commands): add --baseline flag for coverage regression detection

### DIFF
--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -39,6 +39,9 @@ const showUncoveredArgumentName = 'show-uncovered';
 const defaultShowUncovered = false;
 const showUncoveredHelp = 'Display uncovered line numbers';
 
+const baselineArgumentName = 'baseline';
+const baselineHelp = 'Specify a baseline coverage file to compare with.';
+
 const commandDescription = 'Check code coverage';
 const commandName = 'check';
 
@@ -66,12 +69,14 @@ class CheckCoverageCommand extends Command<int> {
       final excludePaths = getExcludePathsArgument();
       final excludeGenerated = getExcludeGeneratedArgument();
       final showUncovered = getShowUncoveredArgument();
+      final baselinePath = getBaselineArgument();
 
       final result = await _service.checkCoverage(
         filePath: filePath,
         minCoverage: minCoverage,
         excludePaths: excludePaths,
         excludeGenerated: excludeGenerated,
+        baselinePath: baselinePath,
       );
 
       _displayResult(
@@ -84,7 +89,11 @@ class CheckCoverageCommand extends Command<int> {
         showUncovered: showUncovered,
       );
 
-      return result.coverage >= minCoverage
+      final passedMinCoverage = result.coverage >= minCoverage;
+      final passedBaseline = result.baselineCoverage == null ||
+          result.coverage >= result.baselineCoverage!;
+
+      return passedMinCoverage && passedBaseline
           ? ExitCode.success.code
           : ExitCode.fail.code;
     } on UsageException catch (e) {
@@ -144,8 +153,25 @@ class CheckCoverageCommand extends Command<int> {
 
       console
         ..writeLine('Minimum coverage: $greenColor$minCoverage%')
-        ..resetColorAttributes()
-        ..writeLine('Current coverage: $color$currentCoverage%');
+        ..resetColorAttributes();
+
+      if (result.baselineCoverage != null) {
+        final baseline = result.baselineCoverage!;
+        final delta =
+            (currentCoverage - baseline).roundToDoubleWithPrecision(2);
+        final deltaPrefix = delta >= 0 ? '+' : '';
+        final deltaColor = delta >= 0 ? greenColor : redColor;
+
+        console
+          ..writeLine('Baseline coverage: $yellowColor$baseline%')
+          ..resetColorAttributes()
+          ..writeLine(
+            'Current coverage: $color$currentCoverage% '
+            '($deltaColor$deltaPrefix$delta%)',
+          );
+      } else {
+        console.writeLine('Current coverage: $color$currentCoverage%');
+      }
     }
   }
 
@@ -244,5 +270,9 @@ class CheckCoverageCommand extends Command<int> {
   bool getShowUncoveredArgument() {
     return globalResults?[showUncoveredArgumentName] as bool? ??
         defaultShowUncovered;
+  }
+
+  String? getBaselineArgument() {
+    return globalResults?[baselineArgumentName] as String?;
   }
 }

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -70,6 +70,11 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
         showUncoveredArgumentName,
         abbr: 'u',
         help: showUncoveredHelp,
+      )
+      ..addOption(
+        baselineArgumentName,
+        abbr: 'b',
+        help: baselineHelp,
       );
 
     addCommand(CheckCoverageCommand(_console, service: coverageService));

--- a/lib/src/extensions/double_extension.dart
+++ b/lib/src/extensions/double_extension.dart
@@ -7,6 +7,14 @@ final redColor = ConsoleColor.brightRed.ansiSetForegroundColorSequence;
 final green100 = '${greenColor}100.0%';
 
 extension DoubleExtension on double {
+  double roundToDoubleWithPrecision(int fractionDigits) {
+    var mod = 1.0;
+    for (var i = 0; i < fractionDigits; i++) {
+      mod *= 10;
+    }
+    return (this * mod).roundToDouble() / mod;
+  }
+
   String getCoverageColorAnsi() {
     return switch (this) {
       100 => greenColor,

--- a/lib/src/models/coverage_result.dart
+++ b/lib/src/models/coverage_result.dart
@@ -1,21 +1,34 @@
+import 'package:cover/src/extensions/double_extension.dart';
 import 'package:cover/src/extensions/record_extension.dart';
 import 'package:lcov_parser/lcov_parser.dart';
 
 class CoverageResult {
-  const CoverageResult({required this.coverage, required this.files});
+  const CoverageResult({
+    required this.coverage,
+    required this.files,
+    this.baselineCoverage,
+  });
 
   final double coverage;
   final List<Record> files;
+  final double? baselineCoverage;
 
   Map<String, dynamic> toJson({
     required double minCoverage,
     List<String> excludePaths = const [],
     bool excludeGenerated = false,
   }) {
+    final delta = baselineCoverage != null
+        ? (coverage - baselineCoverage!).roundToDoubleWithPrecision(2)
+        : null;
+
     return {
       'coverage': coverage,
       'min_coverage': minCoverage,
-      'passed': coverage >= minCoverage,
+      'baseline_coverage': baselineCoverage,
+      'delta': delta,
+      'passed': coverage >= minCoverage &&
+          (baselineCoverage == null || coverage >= baselineCoverage!),
       'timestamp': DateTime.now().toIso8601String(),
       'files_count': files.length,
       'exclude_generated': excludeGenerated,

--- a/lib/src/services/coverage_service.dart
+++ b/lib/src/services/coverage_service.dart
@@ -25,6 +25,37 @@ class CoverageService {
     required double minCoverage,
     List<String> excludePaths = const [],
     bool excludeGenerated = false,
+    String? baselinePath,
+  }) async {
+    final files = await _getCoverageData(
+      filePath: filePath,
+      excludePaths: excludePaths,
+      excludeGenerated: excludeGenerated,
+    );
+
+    final currentCoverage = files.getCodeCoverageResult();
+
+    double? baselineCoverage;
+    if (baselinePath != null && baselinePath.isNotEmpty) {
+      final baselineFiles = await _getCoverageData(
+        filePath: baselinePath,
+        excludePaths: excludePaths,
+        excludeGenerated: excludeGenerated,
+      );
+      baselineCoverage = baselineFiles.getCodeCoverageResult();
+    }
+
+    return CoverageResult(
+      coverage: currentCoverage,
+      files: files,
+      baselineCoverage: baselineCoverage,
+    );
+  }
+
+  Future<List<Record>> _getCoverageData({
+    required String filePath,
+    required List<String> excludePaths,
+    required bool excludeGenerated,
   }) async {
     if (filePath.isEmpty) {
       throw const PathNotFoundException(
@@ -64,9 +95,7 @@ class CoverageService {
       );
     }
 
-    final currentCoverage = files.getCodeCoverageResult();
-
-    return CoverageResult(coverage: currentCoverage, files: files);
+    return files;
   }
 
   Future<List<Record>> _parseCoverageFile(
@@ -74,7 +103,6 @@ class CoverageService {
     List<String> excludedPaths, {
     bool excludeGenerated = false,
   }) async {
-    // Note: filePath is now expected to be a validated, absolute path.
     List<Record> files;
     try {
       files = await Parser.parse(filePath);

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -248,4 +248,52 @@ void main() {
       verifyNever(() => console.resetColorAttributes());
     },
   );
+
+  test('verify check coverage command fails when coverage regresses from baseline', () async {
+    final exitCode = await runner.run([
+      'check',
+      '--path',
+      'test/stubs/lcov_incomplete.info', // 94.52%
+      '--baseline',
+      'test/stubs/lcov_complete.info', // 100%
+      '--min-coverage',
+      '0',
+    ]);
+
+    expect(exitCode, ExitCode.fail.code);
+    verify(() => console.writeLine(any(), any())).called(3); // min, baseline, current
+  });
+
+  test('verify check coverage command succeeds when coverage is higher than baseline', () async {
+    final exitCode = await runner.run([
+      'check',
+      '--path',
+      'test/stubs/lcov_complete.info', // 100%
+      '--baseline',
+      'test/stubs/lcov_incomplete.info', // 94.52%
+    ]);
+
+    expect(exitCode, ExitCode.success.code);
+  });
+
+  test('verify check coverage command JSON includes baseline and delta', () async {
+    final exitCode = await runner.run([
+      'check',
+      '--path',
+      'test/stubs/lcov_incomplete.info', // 94.52%
+      '--baseline',
+      'test/stubs/lcov_complete.info', // 100%
+      '--json',
+    ]);
+
+    expect(exitCode, ExitCode.fail.code);
+    final captured =
+        verify(() => console.writeLine(captureAny(), any())).captured;
+    final jsonOutput = captured.first as String;
+    final decoded = jsonDecode(jsonOutput) as Map<String, dynamic>;
+
+    expect(decoded['baseline_coverage'], 100.0);
+    expect(decoded['delta'], -5.48);
+    expect(decoded['passed'], isFalse);
+  });
 }

--- a/test/src/services/coverage_service_test.dart
+++ b/test/src/services/coverage_service_test.dart
@@ -186,5 +186,27 @@ void main() {
 
       verify(mockDir.resolveSymbolicLinks).called(1);
     });
+
+    test('checkCoverage with baseline returns baseline coverage', () async {
+      final result = await service.checkCoverage(
+        filePath: 'test/stubs/lcov_incomplete.info', // 94.52%
+        minCoverage: 0,
+        baselinePath: 'test/stubs/lcov_complete.info', // 100%
+      );
+
+      expect(result.coverage, 94.52);
+      expect(result.baselineCoverage, 100.0);
+    });
+
+    test('checkCoverage with same baseline has 0 delta', () async {
+      final result = await service.checkCoverage(
+        filePath: 'test/stubs/lcov_complete.info',
+        minCoverage: 0,
+        baselinePath: 'test/stubs/lcov_complete.info',
+      );
+
+      expect(result.coverage, 100.0);
+      expect(result.baselineCoverage, 100.0);
+    });
   });
 }


### PR DESCRIPTION
This PR introduces the **Baseline Comparison** feature to the `cover` CLI tool. Developers and CI/CD pipelines can now compare current code coverage against a baseline LCOV report (e.g., from the `main` branch or a previous build).

### Why is this useful?
Ensuring that code coverage meets an absolute minimum threshold is important, but preventing coverage *regressions* is equally critical in a fast-paced development environment. With this new feature, the CLI will:
- Parse both current and baseline reports using the same exclusion rules.
- Calculate the coverage delta (e.g., `+1.2%` or `-0.5%`).
- **Fail the check** if current coverage is lower than the baseline, even if it's still above the minimum threshold.
- Provide a machine-readable `delta` and `baseline_coverage` in the JSON output for automated reporting.

### Key Changes
- **`CoverageService`**: Refactored to support parsing multiple reports and calculating baseline results.
- **`CheckCoverageCommand`**: Added the `--baseline` (abbr: `-b`) flag and enhanced terminal output to show delta with ANSI colors.
- **`CoverageResult`**: Updated to include baseline data and regression logic in the `passed` status.
- **`DoubleExtension`**: Added a utility for high-precision rounding.

## Verification Results
- **Unit Tests**: Added 5 new test cases covering baseline parsing, regression failure, and JSON output consistency.
- **Manual Verification**: Confirmed that regressing coverage (e.g., from 100% to 94.52%) triggers a failure exit code and displays the negative delta in red.
- **Total Tests**: All 86 tests passed.

---
*PR created automatically by Jules for task [8132045877245627682](https://jules.google.com/task/8132045877245627682) started by @aosorio-avilez*