### PR TITLE
perf(sanitization): optimize character scanning with fast-path for printable ASCII

### DIFF
--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -125,7 +125,8 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
     } catch (e) {
       final message = 'An unexpected error occurred: $e';
       if (isJson) {
-        _console.writeLine(_formatJsonError(message.sanitize(), ExitCode.software));
+        _console
+            .writeLine(_formatJsonError(message.sanitize(), ExitCode.software));
       } else {
         _console.writeErrorLine(message.sanitize());
       }

--- a/lib/src/extensions/string_extension.dart
+++ b/lib/src/extensions/string_extension.dart
@@ -15,6 +15,10 @@ extension StringExtension on String {
 bool _hasAnsiOrControlChars(String s) {
   for (var i = 0; i < s.length; i++) {
     final code = s.codeUnitAt(i);
+    // Fast-path for ASCII printable characters (0x20 - 0x7E) which are the most
+    // common characters in source file paths and error messages.
+    if (code >= 0x20 && code <= 0x7E) continue;
+
     // 0x00-0x1F (control chars including \x1B) and 0x7F (DEL)
     // Also include Unicode Bidi control characters.
     if (code <= 0x1F ||

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -249,7 +249,9 @@ void main() {
     },
   );
 
-  test('verify check coverage command fails when coverage regresses from baseline', () async {
+  test(
+      'verify check coverage command fails when coverage regresses from baseline',
+      () async {
     final exitCode = await runner.run([
       'check',
       '--path',
@@ -261,10 +263,13 @@ void main() {
     ]);
 
     expect(exitCode, ExitCode.fail.code);
-    verify(() => console.writeLine(any(), any())).called(3); // min, baseline, current
+    verify(() => console.writeLine(any(), any()))
+        .called(3); // min, baseline, current
   });
 
-  test('verify check coverage command succeeds when coverage is higher than baseline', () async {
+  test(
+      'verify check coverage command succeeds when coverage is higher than baseline',
+      () async {
     final exitCode = await runner.run([
       'check',
       '--path',
@@ -276,7 +281,8 @@ void main() {
     expect(exitCode, ExitCode.success.code);
   });
 
-  test('verify check coverage command JSON includes baseline and delta', () async {
+  test('verify check coverage command JSON includes baseline and delta',
+      () async {
     final exitCode = await runner.run([
       'check',
       '--path',

--- a/test/src/extensions/string_extension_test.dart
+++ b/test/src/extensions/string_extension_test.dart
@@ -9,6 +9,12 @@ void main() {
         expect(input.sanitize(), input);
       });
 
+      test('returns same string for printable non-ASCII/Unicode characters',
+          () {
+        const input = '¡Hola, Señor! Cómo estás? ✨';
+        expect(input.sanitize(), input);
+      });
+
       test('removes ANSI escape sequences', () {
         const input = 'Hello \x1B[31mRed\x1B[0m World';
         expect(input.sanitize(), 'Hello Red World');


### PR DESCRIPTION
This PR optimizes the `_hasAnsiOrControlChars` utility used for terminal output sanitization. By adding a fast-path for common printable ASCII characters (range 0x20 to 0x7E), we significantly reduce the number of logical comparisons performed for the vast majority of characters in filenames and error messages.

## Impact
- **Speed:** Faster string sanitization, especially for long paths and large error logs.
- **Efficiency:** Reduced CPU cycles per character during sanitization.

## Changes
- Modified `lib/src/extensions/string_extension.dart` to include an early `continue` for printable ASCII characters in the `_hasAnsiOrControlChars` loop.

## Verification
- Ran `melos run analyze` (Success).
- Ran `melos run test` (All 92 tests passed).
- Verified performance stability via `example/bin/cover_benchmark.dart`.

---
*PR created automatically by Jules for task [4508110511640071667](https://jules.google.com/task/4508110511640071667) started by @aosorio-avilez*