### PR TITLE
perf(runner): use asynchronous I/O for version retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- **Perf**: Refactored `getVersion` in `CoverCommandRunner` to use asynchronous I/O and improved robustness with file type validation.
+
 ## 0.7.0
 
 - **Feat**: Added `--failures-only` (abbr: `-f`) flag to the `check` command to filter the report to show only files failing the coverage threshold.

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -187,9 +187,11 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
 
       final pubspecPath = packagePath.resolve('../pubspec.yaml');
       final pubspecFile = File.fromUri(pubspecPath);
-      if (!pubspecFile.existsSync()) return 'unknown';
 
-      final fileContent = pubspecFile.readAsStringSync();
+      final stat = await pubspecFile.stat();
+      if (stat.type != FileSystemEntityType.file) return 'unknown';
+
+      final fileContent = await pubspecFile.readAsString();
       final pubspec = Pubspec.parse(fileContent);
       return pubspec.version?.toString() ?? 'unknown';
     } catch (_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cover
 description: A simple and efficient tool for comprehensive code coverage analysis.
-version: 0.7.0
+version: 0.7.1
 repository: https://github.com/aosorio-avilez/cover
 
 environment:


### PR DESCRIPTION
Refactored the `getVersion` method in `CoverCommandRunner` to use asynchronous file I/O, adhering to the project's architectural guidelines for non-blocking operations in `async` functions. It also adds a check to verify that the `pubspec.yaml` path points to a file before reading it, enhancing the CLI's resilience.

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash

---
*PR created automatically by Jules for task [13675189425426318187](https://jules.google.com/task/13675189425426318187) started by @aosorio-avilez*