### PR TITLE
feat(commands): add --markdown flag for emoji-rich coverage reports

### DIFF
--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -63,6 +63,7 @@ class CheckCoverageCommand extends Command<int> {
     final isJson = getJsonArgument();
 
     try {
+      final isMarkdown = getMarkdownArgument();
       final filePath = getPathArgument();
       final minCoverage = getMinCoverageArgument();
       final displayFiles = getDisplayFilesArgument();
@@ -83,6 +84,7 @@ class CheckCoverageCommand extends Command<int> {
       _displayResult(
         result,
         isJson: isJson,
+        isMarkdown: isMarkdown,
         minCoverage: minCoverage,
         excludePaths: excludePaths,
         excludeGenerated: excludeGenerated,
@@ -131,6 +133,7 @@ class CheckCoverageCommand extends Command<int> {
   void _displayResult(
     CoverageResult result, {
     required bool isJson,
+    required bool isMarkdown,
     required double minCoverage,
     required List<String> excludePaths,
     required bool excludeGenerated,
@@ -149,6 +152,14 @@ class CheckCoverageCommand extends Command<int> {
         ),
       );
       console.writeLine(jsonOutput);
+    } else if (isMarkdown) {
+      _displayMarkdownResult(
+        result,
+        minCoverage: minCoverage,
+        displayFiles: displayFiles,
+        showUncovered: showUncovered,
+        failuresOnly: failuresOnly,
+      );
     } else {
       final color =
           currentCoverage.getCoverageColorAnsi(minCoverage: minCoverage);
@@ -191,6 +202,74 @@ class CheckCoverageCommand extends Command<int> {
       } else {
         console.writeLine('Current coverage: $color$currentCoverage%\x1B[0m');
       }
+    }
+  }
+
+  void _displayMarkdownResult(
+    CoverageResult result, {
+    required double minCoverage,
+    required bool displayFiles,
+    required bool showUncovered,
+    required bool failuresOnly,
+  }) {
+    final currentCoverage = result.coverage;
+    final emoji = currentCoverage.getCoverageEmoji(minCoverage: minCoverage);
+    final progressBar = currentCoverage.getProgressBar(minCoverage: minCoverage);
+
+    console
+      ..writeLine('# $emoji Coverage Report')
+      ..writeLine()
+      ..writeLine('## Summary')
+      ..writeLine()
+      ..writeLine('- **Total Coverage:** $currentCoverage%')
+      ..writeLine('- **Progress:** `$progressBar`')
+      ..writeLine('- **Minimum Required:** $minCoverage%')
+      ..writeLine();
+
+    if (result.baselineCoverage != null) {
+      final baseline = result.baselineCoverage!;
+      final delta = (currentCoverage - baseline).roundToDoubleWithPrecision(2);
+      final deltaPrefix = delta >= 0 ? '+' : '';
+
+      console
+        ..writeLine('## Comparison')
+        ..writeLine()
+        ..writeLine('- **Baseline:** $baseline%')
+        ..writeLine('- **Delta:** $deltaPrefix$delta%')
+        ..writeLine();
+    }
+
+    if (displayFiles) {
+      console
+        ..writeLine('## Files')
+        ..writeLine();
+
+      final headers = [
+        'Status',
+        'File name',
+        'Found Lines',
+        'Hit Lines',
+        'Coverage',
+      ];
+      if (showUncovered) {
+        headers.add('Uncovered Lines');
+      }
+
+      console
+        ..writeLine('| ${headers.join(' | ')} |')
+        ..writeLine('| ${headers.map((_) => '---').join(' | ')} |');
+
+      for (final record in result.files) {
+        if (failuresOnly && record.coveragePercentage >= minCoverage) {
+          continue;
+        }
+        final row = record.toMarkdownRow(
+          showUncovered: showUncovered,
+          minCoverage: minCoverage,
+        );
+        console.writeLine('| ${row.join(' | ')} |');
+      }
+      console.writeLine();
     }
   }
 
@@ -284,6 +363,10 @@ class CheckCoverageCommand extends Command<int> {
 
   bool getJsonArgument() {
     return globalResults?[jsonFlag] as bool? ?? false;
+  }
+
+  bool getMarkdownArgument() {
+    return globalResults?[markdownFlag] as bool? ?? false;
   }
 
   bool getShowUncoveredArgument() {

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -19,6 +19,8 @@ const versionFlag = 'version';
 const versionDescription = 'Print the current version.';
 const jsonFlag = 'json';
 const jsonDescription = 'Output the result in JSON format.';
+const markdownFlag = 'markdown';
+const markdownDescription = 'Output the result in Markdown format.';
 const failuresOnlyArgumentName = 'failures-only';
 const defaultFailuresOnly = false;
 const failuresOnlyHelp =
@@ -41,6 +43,12 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
         abbr: 'j',
         negatable: false,
         help: jsonDescription,
+      )
+      ..addFlag(
+        markdownFlag,
+        abbr: 'k',
+        negatable: false,
+        help: markdownDescription,
       )
       ..addFlag(
         displayFilesArgumentName,

--- a/lib/src/extensions/double_extension.dart
+++ b/lib/src/extensions/double_extension.dart
@@ -24,4 +24,28 @@ extension DoubleExtension on double {
     }
     return redColor;
   }
+
+  String getCoverageEmoji({double minCoverage = 100.0}) {
+    if (this >= minCoverage) {
+      return '🟢';
+    }
+    if (this >= minCoverage * 0.8) {
+      return '🟡';
+    }
+    return '🔴';
+  }
+
+  String getProgressBar({double minCoverage = 100.0}) {
+    final emoji = getCoverageEmoji(minCoverage: minCoverage);
+    final coloredBlock = switch (emoji) {
+      '🟢' => '🟩',
+      '🟡' => '🟨',
+      '🔴' || _ => '🟥',
+    };
+
+    final filledCount = (this / 10).clamp(0, 10).floor();
+    final emptyCount = 10 - filledCount;
+
+    return (coloredBlock * filledCount) + ('⬜' * emptyCount);
+  }
 }

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -92,6 +92,31 @@ extension RecordExtension on Record {
 
     return row;
   }
+
+  List<String> toMarkdownRow({
+    bool showUncovered = false,
+    double minCoverage = 100.0,
+  }) {
+    final percentage = coveragePercentage;
+    final emoji = percentage.getCoverageEmoji(minCoverage: minCoverage);
+    final lines = this.lines;
+    final fileName = file ?? 'null';
+    final sanitizedFile = fileName.sanitize();
+
+    final row = [
+      emoji,
+      sanitizedFile,
+      '${lines?.found ?? 0}',
+      '${lines?.hit ?? 0}',
+      '$percentage%',
+    ];
+
+    if (showUncovered) {
+      row.add(_formatUncoveredLines(uncoveredLines));
+    }
+
+    return row;
+  }
 }
 
 extension RecordListExtension on List<Record> {

--- a/test/src/commands/markdown_report_test.dart
+++ b/test/src/commands/markdown_report_test.dart
@@ -1,0 +1,109 @@
+import 'package:cover/src/cover_command_runner.dart';
+import 'package:cover/src/models/exit_code.dart';
+import 'package:dart_console/dart_console.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../mocks/console_mock.dart';
+
+void main() {
+  late Console console;
+  late CoverCommandRunner runner;
+
+  setUpAll(() {
+    registerFallbackValue(TextAlignment.left);
+  });
+
+  setUp(() {
+    console = ConsoleMock();
+    runner = CoverCommandRunner(console: console);
+  });
+
+  group('CheckCoverageCommand Markdown output', () {
+    test('verify markdown output with --markdown flag', () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--markdown',
+      ]);
+
+      expect(exitCode, ExitCode.fail.code);
+
+      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final output = captured.join('\n');
+
+      expect(output, contains('# 🟡 Coverage Report'));
+      expect(output, contains('## Summary'));
+      expect(output, contains('- **Total Coverage:** 94.52%'));
+      expect(output, contains('- **Progress:** `'));
+      expect(output, contains('| Status | File name | Found Lines | Hit Lines | Coverage |'));
+      expect(output, contains('| --- | --- | --- | --- | --- |'));
+      expect(output, contains('| 🟡 | lib/src/api/auth_api_impl.dart | 16 | 14 | 87.5% |'));
+      expect(output, contains('| 🟢 | lib/src/datasources/auth_data_source.dart | 47 | 47 | 100.0% |'));
+    });
+
+    test('verify markdown output with --markdown and --show-uncovered', () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--markdown',
+        '--show-uncovered',
+      ]);
+
+      expect(exitCode, ExitCode.fail.code);
+
+      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final output = captured.join('\n');
+
+      expect(output, contains('| Status | File name | Found Lines | Hit Lines | Coverage | Uncovered Lines |'));
+      expect(output, contains('| --- | --- | --- | --- | --- | --- |'));
+      expect(output, contains('| 🟡 | lib/src/api/auth_api_impl.dart | 16 | 14 | 87.5% | 20, 22 |'));
+    });
+
+    test('verify markdown output with --markdown and --failures-only', () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--markdown',
+        '--failures-only',
+        '--min-coverage',
+        '90',
+      ]);
+
+      expect(exitCode, ExitCode.success.code);
+
+      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final output = captured.join('\n');
+
+      // lib/src/api/auth_api_impl.dart (87.5%) should be included as it's below 90%
+      expect(output, contains('| 🟡 | lib/src/api/auth_api_impl.dart | 16 | 14 | 87.5% |'));
+      // lib/src/datasources/auth_data_source.dart (100%) should be excluded
+      expect(output, isNot(contains('lib/src/datasources/auth_data_source.dart')));
+    });
+
+    test('verify markdown output with --markdown and --baseline', () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info', // 94.52%
+        '--baseline',
+        'test/stubs/lcov_complete.info', // 100%
+        '--markdown',
+        '--min-coverage',
+        '0',
+      ]);
+
+      expect(exitCode, ExitCode.fail.code);
+
+      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final output = captured.join('\n');
+
+      expect(output, contains('## Comparison'));
+      expect(output, contains('- **Baseline:** 100.0%'));
+      expect(output, contains('- **Delta:** -5.48%'));
+    });
+  });
+}

--- a/test/src/extensions/double_extension_test.dart
+++ b/test/src/extensions/double_extension_test.dart
@@ -46,4 +46,30 @@ void main() {
       );
     });
   });
+
+  group('getCoverageEmoji', () {
+    test('returns 🟢 for 100% coverage and 🔴 for 50% coverage with 100% threshold', () {
+      expect(100.0.getCoverageEmoji(minCoverage: 100.0), '🟢');
+      expect(50.0.getCoverageEmoji(minCoverage: 100.0), '🔴');
+    });
+
+    test('returns 🟡 for 85% coverage with 100% threshold', () {
+      expect(85.0.getCoverageEmoji(minCoverage: 100.0), '🟡');
+    });
+  });
+
+  group('getProgressBar', () {
+    test('returns 10 green squares for 100%', () {
+      expect(100.0.getProgressBar(minCoverage: 100.0), '🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩');
+    });
+
+    test('returns 10 white squares for 0%', () {
+      expect(0.0.getProgressBar(minCoverage: 100.0), '⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜');
+    });
+
+    test('returns 5 yellow squares and 5 white squares for 55% with 60% threshold', () {
+      // 55% coverage against 60% threshold is yellow (55 >= 60*0.8=48)
+      expect(55.0.getProgressBar(minCoverage: 60.0), '🟨🟨🟨🟨🟨⬜⬜⬜⬜⬜');
+    });
+  });
 }

--- a/test/src/extensions/double_extension_test.dart
+++ b/test/src/extensions/double_extension_test.dart
@@ -48,28 +48,32 @@ void main() {
   });
 
   group('getCoverageEmoji', () {
-    test('returns 🟢 for 100% coverage and 🔴 for 50% coverage with 100% threshold', () {
-      expect(100.0.getCoverageEmoji(minCoverage: 100.0), '🟢');
-      expect(50.0.getCoverageEmoji(minCoverage: 100.0), '🔴');
+    test(
+        'returns 🟢 for 100% coverage and 🔴 for 50% coverage with 100% threshold',
+        () {
+      expect(100.0.getCoverageEmoji(), '🟢');
+      expect(50.0.getCoverageEmoji(), '🔴');
     });
 
     test('returns 🟡 for 85% coverage with 100% threshold', () {
-      expect(85.0.getCoverageEmoji(minCoverage: 100.0), '🟡');
+      expect(85.0.getCoverageEmoji(), '🟡');
     });
   });
 
   group('getProgressBar', () {
     test('returns 10 green squares for 100%', () {
-      expect(100.0.getProgressBar(minCoverage: 100.0), '🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩');
+      expect(100.0.getProgressBar(), '🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩');
     });
 
     test('returns 10 white squares for 0%', () {
-      expect(0.0.getProgressBar(minCoverage: 100.0), '⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜');
+      expect(0.0.getProgressBar(), '⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜');
     });
 
-    test('returns 5 yellow squares and 5 white squares for 55% with 60% threshold', () {
+    test(
+        'returns 5 yellow squares and 5 white squares for 55% with 60% threshold',
+        () {
       // 55% coverage against 60% threshold is yellow (55 >= 60*0.8=48)
-      expect(55.0.getProgressBar(minCoverage: 60.0), '🟨🟨🟨🟨🟨⬜⬜⬜⬜⬜');
+      expect(55.0.getProgressBar(minCoverage: 60), '🟨🟨🟨🟨🟨⬜⬜⬜⬜⬜');
     });
   });
 }

--- a/test/src/extensions/record_extension_test.dart
+++ b/test/src/extensions/record_extension_test.dart
@@ -151,6 +151,31 @@ void main() {
 
       await file.delete();
     });
+
+    test('toMarkdownRow returns a list of 5 or 6 strings correctly formatted with emojis', () async {
+      final file = File('test_markdown.info');
+      await file.writeAsString(
+        'SF:test.dart\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record',
+      );
+
+      final records = await Parser.parse(file.path);
+      final record = records.first;
+
+      // Without showUncovered, 100% threshold
+      // 50% coverage -> 🔴 emoji
+      final row = record.toMarkdownRow(minCoverage: 100.0);
+      expect(row.length, 5);
+      expect(row[0], '🔴');
+      expect(row[1], 'test.dart');
+      expect(row[4], '50.0%');
+
+      // With showUncovered
+      final rowWithUncovered = record.toMarkdownRow(showUncovered: true, minCoverage: 100.0);
+      expect(rowWithUncovered.length, 6);
+      expect(rowWithUncovered[5], '1');
+
+      await file.delete();
+    });
   });
 
   group('RecordListExtension', () {

--- a/test/src/extensions/record_extension_test.dart
+++ b/test/src/extensions/record_extension_test.dart
@@ -152,7 +152,9 @@ void main() {
       await file.delete();
     });
 
-    test('toMarkdownRow returns a list of 5 or 6 strings correctly formatted with emojis', () async {
+    test(
+        'toMarkdownRow returns a list of 5 or 6 strings correctly formatted with emojis',
+        () async {
       final file = File('test_markdown.info');
       await file.writeAsString(
         'SF:test.dart\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record',
@@ -163,14 +165,14 @@ void main() {
 
       // Without showUncovered, 100% threshold
       // 50% coverage -> 🔴 emoji
-      final row = record.toMarkdownRow(minCoverage: 100.0);
+      final row = record.toMarkdownRow();
       expect(row.length, 5);
       expect(row[0], '🔴');
       expect(row[1], 'test.dart');
       expect(row[4], '50.0%');
 
       // With showUncovered
-      final rowWithUncovered = record.toMarkdownRow(showUncovered: true, minCoverage: 100.0);
+      final rowWithUncovered = record.toMarkdownRow(showUncovered: true);
       expect(rowWithUncovered.length, 6);
       expect(rowWithUncovered[5], '1');
 


### PR DESCRIPTION
This PR introduces a new `--markdown` (abbr: `-k`) flag to the `check` command, enabling developers and CI/CD pipelines to generate rich, emoji-enhanced coverage reports in Markdown format.

### Why is this useful?
Integration with CI/CD platforms like GitHub Actions often involves posting coverage summaries as PR comments. This new feature provides a "ready-to-use" Markdown output that includes:
- **Status Emojis:** Visual indicators (🟢, 🟡, 🔴) for quick health checks.
- **Progress Bars:** A 10-segment emoji-based progress bar for an immediate sense of coverage scale.
- **Baseline Comparison:** Clearly shows deltas when comparing against a baseline coverage file.
- **Detailed File Table:** A clean Markdown table breaking down coverage per file, supporting all existing filters like `--show-uncovered` and `--failures-only`.

### Changes
- **Extensions:** Enhanced `DoubleExtension` and `RecordExtension` with Markdown formatting logic (emojis, progress bars, and row generation).
- **Commands:** Updated `CheckCoverageCommand` and `CoverCommandRunner` to support the new flag.
- **Tests:** Added comprehensive unit tests and integration tests for the Markdown reporting logic.

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash

---
*PR created automatically by Jules for task [6621928267596888304](https://jules.google.com/task/6621928267596888304) started by @aosorio-avilez*