### PR TITLE
fix(commands): fix markdown injection and ensure consistent json output

### DIFF
--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -149,6 +149,7 @@ class CheckCoverageCommand extends Command<int> {
           minCoverage: minCoverage,
           excludePaths: excludePaths,
           excludeGenerated: excludeGenerated,
+          failuresOnly: failuresOnly,
         ),
       );
       console.writeLine(jsonOutput);
@@ -214,35 +215,36 @@ class CheckCoverageCommand extends Command<int> {
   }) {
     final currentCoverage = result.coverage;
     final emoji = currentCoverage.getCoverageEmoji(minCoverage: minCoverage);
-    final progressBar = currentCoverage.getProgressBar(minCoverage: minCoverage);
+    final progressBar =
+        currentCoverage.getProgressBar(minCoverage: minCoverage);
 
-    console
-      ..writeLine('# $emoji Coverage Report')
-      ..writeLine()
-      ..writeLine('## Summary')
-      ..writeLine()
-      ..writeLine('- **Total Coverage:** $currentCoverage%')
-      ..writeLine('- **Progress:** `$progressBar`')
-      ..writeLine('- **Minimum Required:** $minCoverage%')
-      ..writeLine();
+    final buffer = StringBuffer()
+      ..writeln('# $emoji Coverage Report')
+      ..writeln()
+      ..writeln('## Summary')
+      ..writeln()
+      ..writeln('- **Total Coverage:** $currentCoverage%')
+      ..writeln('- **Progress:** `$progressBar`')
+      ..writeln('- **Minimum Required:** $minCoverage%')
+      ..writeln();
 
     if (result.baselineCoverage != null) {
       final baseline = result.baselineCoverage!;
       final delta = (currentCoverage - baseline).roundToDoubleWithPrecision(2);
       final deltaPrefix = delta >= 0 ? '+' : '';
 
-      console
-        ..writeLine('## Comparison')
-        ..writeLine()
-        ..writeLine('- **Baseline:** $baseline%')
-        ..writeLine('- **Delta:** $deltaPrefix$delta%')
-        ..writeLine();
+      buffer
+        ..writeln('## Comparison')
+        ..writeln()
+        ..writeln('- **Baseline:** $baseline%')
+        ..writeln('- **Delta:** $deltaPrefix$delta%')
+        ..writeln();
     }
 
     if (displayFiles) {
-      console
-        ..writeLine('## Files')
-        ..writeLine();
+      buffer
+        ..writeln('## Files')
+        ..writeln();
 
       final headers = [
         'Status',
@@ -255,9 +257,9 @@ class CheckCoverageCommand extends Command<int> {
         headers.add('Uncovered Lines');
       }
 
-      console
-        ..writeLine('| ${headers.join(' | ')} |')
-        ..writeLine('| ${headers.map((_) => '---').join(' | ')} |');
+      buffer
+        ..writeln('| ${headers.join(' | ')} |')
+        ..writeln('| ${headers.map((_) => '---').join(' | ')} |');
 
       for (final record in result.files) {
         if (failuresOnly && record.coveragePercentage >= minCoverage) {
@@ -267,10 +269,12 @@ class CheckCoverageCommand extends Command<int> {
           showUncovered: showUncovered,
           minCoverage: minCoverage,
         );
-        console.writeLine('| ${row.join(' | ')} |');
+        buffer.writeln('| $row |');
       }
-      console.writeLine();
+      buffer.writeln();
     }
+
+    console.write(buffer.toString());
   }
 
   int _handleError(

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -195,9 +195,11 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
 
       final pubspecPath = packagePath.resolve('../pubspec.yaml');
       final pubspecFile = File.fromUri(pubspecPath);
-      if (!pubspecFile.existsSync()) return 'unknown';
 
-      final fileContent = pubspecFile.readAsStringSync();
+      final stat = await pubspecFile.stat();
+      if (stat.type != FileSystemEntityType.file) return 'unknown';
+
+      final fileContent = await pubspecFile.readAsString();
       final pubspec = Pubspec.parse(fileContent);
       return pubspec.version?.toString() ?? 'unknown';
     } catch (_) {

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -93,7 +93,7 @@ extension RecordExtension on Record {
     return row;
   }
 
-  List<String> toMarkdownRow({
+  String toMarkdownRow({
     bool showUncovered = false,
     double minCoverage = 100.0,
   }) {
@@ -101,21 +101,27 @@ extension RecordExtension on Record {
     final emoji = percentage.getCoverageEmoji(minCoverage: minCoverage);
     final lines = this.lines;
     final fileName = file ?? 'null';
-    final sanitizedFile = fileName.sanitize();
+    final sanitizedFile = fileName.sanitize().replaceAll('|', r'\|');
 
-    final row = [
-      emoji,
-      sanitizedFile,
-      '${lines?.found ?? 0}',
-      '${lines?.hit ?? 0}',
-      '$percentage%',
-    ];
+    final buffer = StringBuffer()
+      ..write(emoji)
+      ..write(' | ')
+      ..write(sanitizedFile)
+      ..write(' | ')
+      ..write(lines?.found ?? 0)
+      ..write(' | ')
+      ..write(lines?.hit ?? 0)
+      ..write(' | ')
+      ..write(percentage)
+      ..write('%');
 
     if (showUncovered) {
-      row.add(_formatUncoveredLines(uncoveredLines));
+      buffer
+        ..write(' | ')
+        ..write(_formatUncoveredLines(uncoveredLines));
     }
 
-    return row;
+    return buffer.toString();
   }
 }
 

--- a/lib/src/models/coverage_result.dart
+++ b/lib/src/models/coverage_result.dart
@@ -17,10 +17,15 @@ class CoverageResult {
     required double minCoverage,
     List<String> excludePaths = const [],
     bool excludeGenerated = false,
+    bool failuresOnly = false,
   }) {
     final delta = baselineCoverage != null
         ? (coverage - baselineCoverage!).roundToDoubleWithPrecision(2)
         : null;
+
+    final filteredFiles = failuresOnly
+        ? files.where((f) => f.coveragePercentage < minCoverage).toList()
+        : files;
 
     return {
       'coverage': coverage,
@@ -30,10 +35,11 @@ class CoverageResult {
       'passed': coverage >= minCoverage &&
           (baselineCoverage == null || coverage >= baselineCoverage!),
       'timestamp': DateTime.now().toIso8601String(),
-      'files_count': files.length,
+      'files_count': filteredFiles.length,
       'exclude_generated': excludeGenerated,
       'excluded_paths': excludePaths,
-      'files': files.map((file) => file.toJson()).toList(),
+      'failures_only': failuresOnly,
+      'files': filteredFiles.map((file) => file.toJson()).toList(),
     };
   }
 }

--- a/test/src/commands/markdown_report_test.dart
+++ b/test/src/commands/markdown_report_test.dart
@@ -30,7 +30,7 @@ void main() {
 
       expect(exitCode, ExitCode.fail.code);
 
-      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final captured = verify(() => console.write(captureAny())).captured;
       final output = captured.join('\n');
 
       expect(output, contains('# 🟡 Coverage Report'));
@@ -54,7 +54,7 @@ void main() {
 
       expect(exitCode, ExitCode.fail.code);
 
-      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final captured = verify(() => console.write(captureAny())).captured;
       final output = captured.join('\n');
 
       expect(output, contains('| Status | File name | Found Lines | Hit Lines | Coverage | Uncovered Lines |'));
@@ -75,7 +75,7 @@ void main() {
 
       expect(exitCode, ExitCode.success.code);
 
-      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final captured = verify(() => console.write(captureAny())).captured;
       final output = captured.join('\n');
 
       // lib/src/api/auth_api_impl.dart (87.5%) should be included as it's below 90%
@@ -98,7 +98,7 @@ void main() {
 
       expect(exitCode, ExitCode.fail.code);
 
-      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final captured = verify(() => console.write(captureAny())).captured;
       final output = captured.join('\n');
 
       expect(output, contains('## Comparison'));

--- a/test/src/extensions/record_extension_test.dart
+++ b/test/src/extensions/record_extension_test.dart
@@ -153,7 +153,7 @@ void main() {
     });
 
     test(
-        'toMarkdownRow returns a list of 5 or 6 strings correctly formatted with emojis',
+        'toMarkdownRow returns a string correctly formatted with emojis',
         () async {
       final file = File('test_markdown.info');
       await file.writeAsString(
@@ -166,15 +166,13 @@ void main() {
       // Without showUncovered, 100% threshold
       // 50% coverage -> 🔴 emoji
       final row = record.toMarkdownRow();
-      expect(row.length, 5);
-      expect(row[0], '🔴');
-      expect(row[1], 'test.dart');
-      expect(row[4], '50.0%');
+      expect(row, contains('🔴'));
+      expect(row, contains('test.dart'));
+      expect(row, contains('50.0%'));
 
       // With showUncovered
       final rowWithUncovered = record.toMarkdownRow(showUncovered: true);
-      expect(rowWithUncovered.length, 6);
-      expect(rowWithUncovered[5], '1');
+      expect(rowWithUncovered, contains(' | 1'));
 
       await file.delete();
     });


### PR DESCRIPTION
This PR improves the robustness and security of the `cover` CLI tool by addressing several issues:

- **Markdown Injection Fix:** Filenames containing the pipe character (`|`) no longer break the Markdown table structure in reports. They are now properly escaped using `\|`.
- **Consistent JSON Output:** The `--failures-only` flag is now correctly respected when generating JSON output, ensuring consistency with terminal and Markdown reports.
- **Robust Version Retrieval:** The `getVersion` logic in `CoverCommandRunner` has been refactored to use asynchronous I/O and `stat()` for file type verification, preventing potential issues and adhering to project standards.
- **Performance Optimization:** Markdown report generation has been optimized to use `StringBuffer` for buffering output, reducing terminal I/O calls.

---
*PR created automatically by Jules for task [14197128232824809685](https://jules.google.com/task/14197128232824809685) started by @aosorio-avilez*