### PR TITLE
feat(commands): add --github-annotations flag for GitHub Actions integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0
+
+- **Feat**: Added `--github-annotations` (abbr: `-g`) flag to the `check` command to generate GitHub Actions warnings for uncovered lines.
+
 ## 0.7.1
 
 - **Perf**: Optimized Markdown and JSON reporting for large datasets by batching console writes and caching calculations.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - 🔍 **Missing Lines**: Shows exactly which line numbers are missing coverage with `--show-uncovered`.
 - 🧹 **Smart Filters**: Ignore generated files (`.g.dart`, `.freezed.dart`, etc.) with a single flag.
 - 🤖 **JSON Output**: Perfect for integration with other tools.
+- 🐙 **GitHub Actions**: Generate coverage annotations for CI/CD pipelines with `--github-annotations`.
 - 📉 **Regression Detection**: Compare current coverage against a baseline file using `--baseline`.
 - 🛡️ **Secure**: Protected against ANSI injection attacks and features robust error handling.
 
@@ -45,6 +46,9 @@ $ cover check --exclude-generated --excluded-paths "lib/generated, lib/src/legac
 # Get output in JSON format
 $ cover check --json
 
+# Generate GitHub Actions annotations
+$ cover check --github-annotations
+
 # Compare against a baseline (e.g. from main branch)
 $ cover check --baseline coverage/lcov.base.info
 ```
@@ -59,6 +63,7 @@ $ cover check --baseline coverage/lcov.base.info
 | `--exclude-generated`| | Ignores `.g.dart`, `.freezed.dart`, etc. | `false` |
 | `--excluded-paths`| `-e` | Comma-separated paths to exclude | `""` |
 | `--json` | `-j` | Output in JSON format | `false` |
+| `--github-annotations`| `-g` | Output GitHub Actions annotations | `false` |
 | `--baseline` | `-b` | Baseline LCOV file to compare with | `null` |
 
 ## 🛠️ Programmatic Usage

--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -42,6 +42,10 @@ const showUncoveredHelp = 'Display uncovered line numbers';
 const baselineArgumentName = 'baseline';
 const baselineHelp = 'Specify a baseline coverage file to compare with.';
 
+const githubAnnotationsArgumentName = githubAnnotationsFlag;
+const defaultGithubAnnotations = false;
+const githubAnnotationsHelp = githubAnnotationsDescription;
+
 const commandDescription = 'Check code coverage';
 const commandName = 'check';
 
@@ -81,10 +85,13 @@ class CheckCoverageCommand extends Command<int> {
         baselinePath: baselinePath,
       );
 
+      final githubAnnotations = getGitHubAnnotationsArgument();
+
       _displayResult(
         result,
         isJson: isJson,
         isMarkdown: isMarkdown,
+        githubAnnotations: githubAnnotations,
         minCoverage: minCoverage,
         excludePaths: excludePaths,
         excludeGenerated: excludeGenerated,
@@ -134,6 +141,7 @@ class CheckCoverageCommand extends Command<int> {
     CoverageResult result, {
     required bool isJson,
     required bool isMarkdown,
+    required bool githubAnnotations,
     required double minCoverage,
     required List<String> excludePaths,
     required bool excludeGenerated,
@@ -153,6 +161,14 @@ class CheckCoverageCommand extends Command<int> {
         ),
       );
       console.writeLine(jsonOutput);
+    } else if (githubAnnotations) {
+      for (final record in result.files) {
+        final annotations =
+            record.toGitHubAnnotations(minCoverage: minCoverage);
+        for (final annotation in annotations) {
+          console.writeLine(annotation);
+        }
+      }
     } else if (isMarkdown) {
       _displayMarkdownResult(
         result,
@@ -382,6 +398,11 @@ class CheckCoverageCommand extends Command<int> {
   bool getShowUncoveredArgument() {
     return globalResults?[showUncoveredArgumentName] as bool? ??
         defaultShowUncovered;
+  }
+
+  bool getGitHubAnnotationsArgument() {
+    return globalResults?[githubAnnotationsArgumentName] as bool? ??
+        defaultGithubAnnotations;
   }
 
   String? getBaselineArgument() {

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -21,6 +21,9 @@ const jsonFlag = 'json';
 const jsonDescription = 'Output the result in JSON format.';
 const markdownFlag = 'markdown';
 const markdownDescription = 'Output the result in Markdown format.';
+const githubAnnotationsFlag = 'github-annotations';
+const githubAnnotationsDescription =
+    'Output the result as GitHub Actions annotations.';
 const failuresOnlyArgumentName = 'failures-only';
 const defaultFailuresOnly = false;
 const failuresOnlyHelp =
@@ -49,6 +52,12 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
         abbr: 'k',
         negatable: false,
         help: markdownDescription,
+      )
+      ..addFlag(
+        githubAnnotationsFlag,
+        abbr: 'g',
+        negatable: false,
+        help: githubAnnotationsDescription,
       )
       ..addFlag(
         displayFilesArgumentName,

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -131,6 +131,44 @@ extension RecordExtension on Record {
 
     return buffer.toString();
   }
+
+  List<String> toGitHubAnnotations({double minCoverage = 100.0}) {
+    if (coveragePercentage >= minCoverage) return [];
+
+    final uncovered = uncoveredLines;
+    if (uncovered.isEmpty) return [];
+
+    final fileName = file ?? 'unknown';
+    final sanitizedFile = fileName.sanitize();
+    final annotations = <String>[];
+
+    var start = uncovered[0];
+    var end = uncovered[0];
+
+    final len = uncovered.length;
+    for (var i = 1; i < len; i++) {
+      final current = uncovered[i];
+      if (current == end + 1) {
+        end = current;
+      } else {
+        annotations.add(
+          '::warning file=$sanitizedFile,line=$start,endLine=$end:: '
+          'Coverage is below threshold ($minCoverage%). '
+          'Lines $start-$end are not covered.',
+        );
+        start = current;
+        end = current;
+      }
+    }
+
+    annotations.add(
+      '::warning file=$sanitizedFile,line=$start,endLine=$end:: '
+      'Coverage is below threshold ($minCoverage%). '
+      'Lines $start-$end are not covered.',
+    );
+
+    return annotations;
+  }
 }
 
 extension RecordListExtension on List<Record> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cover
 description: A simple and efficient tool for comprehensive code coverage analysis.
-version: 0.7.1
+version: 0.8.0
 repository: https://github.com/aosorio-avilez/cover
 
 environment:

--- a/test/src/commands/github_annotations_test.dart
+++ b/test/src/commands/github_annotations_test.dart
@@ -1,0 +1,86 @@
+import 'package:cover/src/cover_command_runner.dart';
+import 'package:cover/src/models/exit_code.dart';
+import 'package:dart_console/dart_console.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../mocks/console_mock.dart';
+
+void main() {
+  late Console console;
+  late CoverCommandRunner runner;
+
+  setUpAll(() {
+    registerFallbackValue(TextAlignment.left);
+  });
+
+  setUp(() {
+    console = ConsoleMock();
+    runner = CoverCommandRunner(console: console);
+  });
+
+  test(
+    'verify check coverage command outputs GitHub annotations with --github-annotations flag',
+    () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--github-annotations',
+        '--min-coverage',
+        '100',
+      ]);
+
+      expect(exitCode, ExitCode.fail.code);
+
+      final captured = verify(() => console.writeLine(captureAny())).captured;
+      final output = captured.map((e) => e as String).join('\n');
+
+      expect(output, contains('::warning file=lib/src/api/auth_api_impl.dart,line=20,endLine=20::'));
+      expect(output, contains('::warning file=lib/src/api/auth_api_impl.dart,line=22,endLine=22::'));
+      expect(output, contains('Coverage is below threshold (100.0%). Lines 20-20 are not covered.'));
+
+      expect(output, contains('::warning file=lib/src/pages/forgot_password_page.dart,line=33,endLine=35::'));
+      expect(output, contains('::warning file=lib/src/pages/forgot_password_page.dart,line=52,endLine=55::'));
+    },
+  );
+
+  test(
+    'verify check coverage command does not output annotations for passing files',
+    () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_complete.info',
+        '--github-annotations',
+        '--min-coverage',
+        '100',
+      ]);
+
+      expect(exitCode, ExitCode.success.code);
+      verifyNever(() => console.writeLine(any()));
+    },
+  );
+
+  test(
+    'verify GitHub annotations respect custom min-coverage',
+    () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--github-annotations',
+        '--min-coverage',
+        '10', // Very low, most files will pass
+      ]);
+
+      expect(exitCode, ExitCode.success.code);
+
+      // All files in lcov_incomplete.info have > 10% coverage except maybe if they are empty
+      // lib/src/api/auth_api_impl.dart has 14/16 = 87.5%
+      // lib/src/pages/forgot_password_page.dart has 28/54 = 51.85%
+
+      verifyNever(() => console.writeLine(any()));
+    },
+  );
+}


### PR DESCRIPTION
## Description
This PR introduces the `--github-annotations` (abbr: `-g`) flag to the `check` command. 
When this flag is used, `cover` will output GitHub Actions warning annotations for any file that falls below the required coverage threshold.

These annotations group consecutive uncovered lines into ranges (e.g., `lines 20-22`), allowing developers to see exactly where coverage is missing directly within the GitHub Pull Request UI.

This feature significantly improves the Developer Experience (DX) when using `cover` in CI/CD pipelines, as it eliminates the need to manually check local reports or scan through large logs to find uncovered code.

## What type of change?
- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Trash

---
*PR created automatically by Jules for task [17813834325749906500](https://jules.google.com/task/17813834325749906500) started by @aosorio-avilez*