### PR TITLE
perf(service): optimize record filtering and display loops

### DIFF
--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -167,13 +167,15 @@ class CheckCoverageCommand extends Command<int> {
       if (displayFiles) {
         final table = buildCoverageFileTable(showUncovered: showUncovered);
         for (final record in result.files) {
-          if (failuresOnly && record.coveragePercentage >= minCoverage) {
+          final percentage = record.coveragePercentage;
+          if (failuresOnly && percentage >= minCoverage) {
             continue;
           }
           table.insertRow(
             record.toRow(
               showUncovered: showUncovered,
               minCoverage: minCoverage,
+              percentage: percentage,
             ),
           );
         }
@@ -261,12 +263,14 @@ class CheckCoverageCommand extends Command<int> {
         ..writeLine('| ${headers.map((_) => '---').join(' | ')} |');
 
       for (final record in result.files) {
-        if (failuresOnly && record.coveragePercentage >= minCoverage) {
+        final percentage = record.coveragePercentage;
+        if (failuresOnly && percentage >= minCoverage) {
           continue;
         }
         final row = record.toMarkdownRow(
           showUncovered: showUncovered,
           minCoverage: minCoverage,
+          percentage: percentage,
         );
         console.writeLine('| ${row.join(' | ')} |');
       }

--- a/lib/src/extensions/record_extension.dart
+++ b/lib/src/extensions/record_extension.dart
@@ -65,16 +65,21 @@ extension RecordExtension on Record {
     };
   }
 
-  List<Object> toRow({bool showUncovered = false, double minCoverage = 100.0}) {
-    final percentage = coveragePercentage;
-    final color = percentage.getCoverageColorAnsi(minCoverage: minCoverage);
+  List<Object> toRow({
+    bool showUncovered = false,
+    double minCoverage = 100.0,
+    double? percentage,
+  }) {
+    final effectivePercentage = percentage ?? coveragePercentage;
+    final color =
+        effectivePercentage.getCoverageColorAnsi(minCoverage: minCoverage);
     final lines = this.lines;
 
     // Optimization: Use a fast-path for 100% coverage by using the `green100`
     // constant (a pre-interpolated string from `DoubleExtension`), which
     // eliminates redundant string allocations and interpolations.
     final formattedPercentage =
-        percentage == 100 ? green100 : '$color$percentage%';
+        effectivePercentage == 100 ? green100 : '$color$effectivePercentage%';
 
     final fileName = file ?? 'null';
     final sanitizedFile = fileName.sanitize();
@@ -96,9 +101,11 @@ extension RecordExtension on Record {
   List<String> toMarkdownRow({
     bool showUncovered = false,
     double minCoverage = 100.0,
+    double? percentage,
   }) {
-    final percentage = coveragePercentage;
-    final emoji = percentage.getCoverageEmoji(minCoverage: minCoverage);
+    final effectivePercentage = percentage ?? coveragePercentage;
+    final emoji =
+        effectivePercentage.getCoverageEmoji(minCoverage: minCoverage);
     final lines = this.lines;
     final fileName = file ?? 'null';
     final sanitizedFile = fileName.sanitize();
@@ -108,7 +115,7 @@ extension RecordExtension on Record {
       sanitizedFile,
       '${lines?.found ?? 0}',
       '${lines?.hit ?? 0}',
-      '$percentage%',
+      '$effectivePercentage%',
     ];
 
     if (showUncovered) {

--- a/lib/src/services/coverage_service.dart
+++ b/lib/src/services/coverage_service.dart
@@ -401,45 +401,43 @@ class CoverageService {
     List<String> excludedPaths, {
     bool excludeGenerated = false,
   }) {
+    final currentPath = _currentDirectory.path;
+    final validExcludedPaths = excludedPaths.where((e) => e.isNotEmpty).toSet();
+
+    RegExp? regExp;
+    if (validExcludedPaths.isNotEmpty || excludeGenerated) {
+      if (validExcludedPaths.isEmpty && excludeGenerated) {
+        regExp = _generatedRegExp;
+      } else {
+        final patterns = validExcludedPaths.map(RegExp.escape).toList();
+        if (excludeGenerated) {
+          patterns.add(_generatedPattern);
+        }
+        regExp = RegExp(patterns.join('|'), caseSensitive: false);
+      }
+    }
+
     files.retainWhere((record) {
       final file = record.file;
       if (file == null || file.isEmpty) return false;
 
-      final relativePath = path.isAbsolute(file)
-          ? path.relative(file, from: _currentDirectory.path)
-          : file;
+      // 1. Exclude test files
+      final relativePath =
+          path.isAbsolute(file) ? path.relative(file, from: currentPath) : file;
 
-      final segments = path.split(relativePath);
-      if (segments.isNotEmpty && segments.first == 'test') {
+      if (relativePath.startsWith('test${path.separator}') ||
+          relativePath == 'test') {
         return false;
       }
+
+      // 2. Exclude paths and generated files
+      if (regExp != null && regExp.hasMatch(file)) {
+        return false;
+      }
+
       return true;
     });
 
-    final validExcludedPaths = excludedPaths.where((e) => e.isNotEmpty).toSet();
-
-    if (validExcludedPaths.isEmpty && !excludeGenerated) {
-      return files;
-    }
-
-    RegExp regExp;
-
-    if (validExcludedPaths.isEmpty && excludeGenerated) {
-      regExp = _generatedRegExp;
-    } else {
-      final patterns = validExcludedPaths.map(RegExp.escape).toList();
-
-      if (excludeGenerated) {
-        patterns.add(_generatedPattern);
-      }
-
-      regExp = RegExp(patterns.join('|'), caseSensitive: false);
-    }
-
-    files.retainWhere((record) {
-      final file = record.file ?? '';
-      return !regExp.hasMatch(file);
-    });
     return files;
   }
 


### PR DESCRIPTION
This PR implements two key performance optimizations to the `cover` CLI tool to improve execution speed and reduce memory allocations, especially when processing large LCOV files.

### 1. Optimized Record Filtering
In `CoverageService._filterRecords`, I consolidated multiple filtering passes into a single `retainWhere` loop. I also replaced the expensive `path.split()` operation, which was being called for every coverage record, with a much faster `startsWith` check to exclude the `test/` directory. This significantly reduces `List` and `String` allocations during the parsing phase.

### 2. Cached Coverage Calculations
I updated `CheckCoverageCommand` and `RecordExtension` to reuse the coverage percentage calculation. Previously, the percentage was being recalculated multiple times for each record (once for threshold checking and again for each cell in the output table). Now, it is calculated once per record and reused, which eliminates redundant floating-point math and rounding operations in the hot path of report generation.

## Impact
- **Faster Parsing:** Reduced overhead during file filtering.
- **Efficient Reporting:** Lower CPU usage when generating large console or Markdown tables.
- **Lower Memory Footprint:** Fewer short-lived object allocations during LCOV processing.

---
*PR created automatically by Jules for task [12295857172855838480](https://jules.google.com/task/12295857172855838480) started by @aosorio-avilez*