### PR TITLE
refactor(services): enhance CoverageService resilience and path security

### DIFF
--- a/lib/src/services/coverage_service.dart
+++ b/lib/src/services/coverage_service.dart
@@ -292,26 +292,39 @@ class CoverageService {
       final source = entry['source'] as String?;
       if (source == null || source.isEmpty) continue;
 
-      final resolvedPath = await _resolveSourcePath(source, packageName);
-      if (resolvedPath == null) continue;
+      try {
+        final resolvedPath = await _resolveSourcePath(source, packageName);
+        if (resolvedPath == null) continue;
 
-      final hits = entry['hits'];
-      if (hits is! List) continue;
+        final hits = entry['hits'];
+        if (hits is! List) continue;
 
-      final lineHits = mergedHits.putIfAbsent(resolvedPath, () => <int, int>{});
-      final len = hits.length;
-      for (var i = 0; i < len - 1; i += 2) {
-        final line = hits[i];
-        final hit = hits[i + 1];
-        if (line is int && hit is int) {
-          lineHits[line] = (lineHits[line] ?? 0) + hit;
+        final lineHits =
+            mergedHits.putIfAbsent(resolvedPath, () => <int, int>{});
+        final len = hits.length;
+        for (var i = 0; i < len - 1; i += 2) {
+          final line = hits[i];
+          final hit = hits[i + 1];
+          if (line is int && hit is int) {
+            lineHits[line] = (lineHits[line] ?? 0) + hit;
+          }
         }
+      } catch (_) {
+        // Sentinel: Gracefully skip entries that fail resolution
+        // (e.g., malformed URIs) to ensure tool resilience and prevent crashes.
+        continue;
       }
     }
   }
 
   Future<String?> _resolveSourcePath(String source, String packageName) async {
-    final decodedSource = Uri.decodeComponent(source);
+    final String decodedSource;
+    try {
+      decodedSource = Uri.decodeComponent(source);
+    } catch (_) {
+      // Sentinel: Skip invalid percent-encoding to prevent ArgumentError.
+      return null;
+    }
 
     if (decodedSource.startsWith('package:')) {
       final packagePrefix = 'package:$packageName/';
@@ -328,10 +341,17 @@ class CoverageService {
     if (decodedSource.startsWith('file://')) {
       final uri = Uri.tryParse(decodedSource);
       if (uri != null) {
-        final filePath = uri.toFilePath();
-        final relative = path.relative(filePath, from: _currentDirectory.path);
-        if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
-          return relative;
+        try {
+          final filePath = uri.toFilePath();
+          final relative =
+              path.relative(filePath, from: _currentDirectory.path);
+          if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
+            return relative;
+          }
+        } catch (_) {
+          // Sentinel: Skip cross-device paths or invalid URIs to prevent
+          // unhandled exceptions during JSON coverage processing.
+          return null;
         }
       }
       return null;
@@ -341,9 +361,16 @@ class CoverageService {
     final absolutePath = path.isAbsolute(decodedSource)
         ? decodedSource
         : path.join(_currentDirectory.path, decodedSource);
-    final relative = path.relative(absolutePath, from: _currentDirectory.path);
-    if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
-      return relative;
+    try {
+      final relative =
+          path.relative(absolutePath, from: _currentDirectory.path);
+      if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
+        return relative;
+      }
+    } catch (_) {
+      // Sentinel: Prevent crashes if absolute path cannot be made relative
+      // (e.g., different drive letters on Windows).
+      return null;
     }
 
     return null;
@@ -405,11 +432,25 @@ class CoverageService {
       final file = record.file;
       if (file == null || file.isEmpty) return false;
 
-      final relativePath = path.isAbsolute(file)
-          ? path.relative(file, from: _currentDirectory.path)
-          : file;
+      String relativePath;
+      try {
+        relativePath = path.isAbsolute(file)
+            ? path.relative(file, from: _currentDirectory.path)
+            : file;
+      } catch (_) {
+        // Sentinel: If path cannot be made relative, keep the original path
+        // for later processing or filtering.
+        relativePath = file;
+      }
 
-      final segments = path.split(relativePath);
+      final normalizedPath = path.normalize(relativePath);
+
+      // Sentinel Security: Skip records that point outside the working directory.
+      if (normalizedPath.startsWith('..')) {
+        return false;
+      }
+
+      final segments = path.split(normalizedPath);
       if (segments.isNotEmpty && segments.first == 'test') {
         return false;
       }

--- a/test/security_test.dart
+++ b/test/security_test.dart
@@ -53,7 +53,7 @@ void main() {
 
         try {
           await insideFile.writeAsString(
-            'TN:\nSF:/path/to/file\nDA:1,1\nLF:1\nLH:1\nend_of_record',
+            'TN:\nSF:lib/file.dart\nDA:1,1\nLF:1\nLH:1\nend_of_record',
           );
 
           final service = CoverageService(currentDirectory: tempDir);
@@ -120,7 +120,7 @@ void main() {
         );
         final realFile = File('${tempDir.path}/real.info');
         await realFile.writeAsString(
-          'TN:\nSF:/path/to/file\nDA:1,1\nLF:1\nLH:1\nend_of_record',
+          'TN:\nSF:lib/file.dart\nDA:1,1\nLF:1\nLH:1\nend_of_record',
         );
 
         final linkPath = path.join(tempDir.path, 'link.info');

--- a/test/src/services/coverage_service_robustness_test.dart
+++ b/test/src/services/coverage_service_robustness_test.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+import 'package:cover/src/services/coverage_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CoverageService Robustness Reproduction', () {
+    late CoverageService service;
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('cover_robustness_repro');
+      service = CoverageService(currentDirectory: tempDir);
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('should exclude files in test directory even if path starts with ./', () async {
+      final lcovFile = File('${tempDir.path}/lcov.info');
+      await lcovFile.writeAsString('''
+SF:./test/my_test.dart
+DA:1,1
+LF:1
+LH:1
+end_of_record
+SF:lib/my_code.dart
+DA:1,1
+LF:1
+LH:1
+end_of_record
+''');
+
+      final result = await service.checkCoverage(filePath: lcovFile.path, minCoverage: 0);
+
+      // Currently, SF:./test/my_test.dart might not be excluded
+      // because path.split('./test/my_test.dart') gives ['.', 'test', 'my_test.dart']
+      // and it checks segments.first == 'test'.
+
+      final filenames = result.files.map((f) => f.file).toList();
+      expect(filenames, isNot(contains('./test/my_test.dart')));
+      expect(filenames, contains('lib/my_code.dart'));
+    });
+
+    test('should not fail entire JSON parsing if one entry has malformed source URI', () async {
+      final jsonFile = File('${tempDir.path}/coverage.json');
+      await jsonFile.writeAsString('''
+{
+  "coverage": [
+    {
+      "source": "package:cover/%",
+      "hits": [1, 1]
+    },
+    {
+      "source": "package:cover/lib/valid.dart",
+      "hits": [1, 1]
+    }
+  ]
+}
+''', flush: true);
+
+      // We need a pubspec.yaml so it knows the package name 'cover'
+      final pubspec = File('${tempDir.path}/pubspec.yaml');
+      await pubspec.writeAsString('name: cover\n');
+
+      // This currently throws FormatException because _parseJsonCoverage catches the ArgumentError
+      // from Uri.decodeComponent and rethrows as FormatException, aborting the whole file.
+      final result = await service.checkCoverage(filePath: jsonFile.path, minCoverage: 0);
+
+      expect(result.files, hasLength(1));
+      expect(result.files.first.file, contains('valid.dart'));
+    });
+
+    test('should skip records that point outside working directory (path traversal)', () async {
+      final lcovFile = File('${tempDir.path}/lcov_traversal.info');
+      await lcovFile.writeAsString('''
+SF:../outside.dart
+DA:1,1
+LF:1
+LH:1
+end_of_record
+SF:lib/inside.dart
+DA:1,1
+LF:1
+LH:1
+end_of_record
+''');
+
+      final result = await service.checkCoverage(filePath: lcovFile.path, minCoverage: 0);
+
+      final filenames = result.files.map((f) => f.file).toList();
+      expect(filenames, isNot(contains('../outside.dart')));
+      expect(filenames, contains('lib/inside.dart'));
+    });
+  });
+}


### PR DESCRIPTION
### Description
This PR enhances the robustness and security of the `CoverageService` by addressing several fragility issues related to path resolution and data parsing.

Key improvements include:
- **Resilient JSON Parsing:** The service now gracefully skips individual malformed entries (e.g., invalid URIs or percent-encoding) in JSON coverage files instead of failing the entire check.
- **Improved Path Normalization:** Fixed a bug where files in the `test/` directory were not correctly excluded if the path started with `./`.
- **Cross-Device Path Handling:** Added `try-catch` blocks around `path.relative` to prevent crashes on Windows when coverage files contain paths from different drives.
- **Enhanced Path Traversal Security:** The `_filterRecords` method now explicitly rejects any coverage records pointing outside the current working directory.
- **Documentation:** Added explanatory comments to catch blocks to clarify the resilience strategy.

### Changes
- Modified `lib/src/services/coverage_service.dart` to include robust error handling and path normalization.
- Updated `test/security_test.dart` to accommodate strict path normalization in LCOV files.
- Added `test/src/services/coverage_service_robustness_test.dart` to verify the new resilience features.

---
*PR created automatically by Jules for task [17192397464059315313](https://jules.google.com/task/17192397464059315313) started by @aosorio-avilez*