### PR TITLE
perf(service): optimize memory footprint when merging multiple coverage files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+- **Perf**: Optimize memory footprint when merging multiple coverage files.
+
 ## 0.8.0
 
 - **Feat**: Added `--github-annotations` (abbr: `-g`) flag to the `check` command to generate GitHub Actions warnings for uncovered lines.

--- a/lib/src/services/coverage_service.dart
+++ b/lib/src/services/coverage_service.dart
@@ -243,33 +243,52 @@ class CoverageService {
   }
 
   List<Record> _mergeRecords(List<List<Record>> recordsLists) {
-    final merged = <String, Record>{};
+    final defaultHits = <String, Record>{};
+    final mergedHits = <String, Map<int, int>>{};
+
     for (final list in recordsLists) {
       for (final record in list) {
         final file = record.file;
         if (file == null) continue;
-        if (!merged.containsKey(file)) {
-          merged[file] = record;
+
+        if (!defaultHits.containsKey(file) && !mergedHits.containsKey(file)) {
+          defaultHits[file] = record;
         } else {
-          final existing = merged[file]!;
-          final existingDetails = existing.lines?.details ?? [];
-          final incomingDetails = record.lines?.details ?? [];
-          final lineHits = <int, int>{};
-          for (final d in existingDetails) {
-            if (d.line != null) {
-              lineHits[d.line!] = (lineHits[d.line!] ?? 0) + (d.hit ?? 0);
+          final lineHits = mergedHits.putIfAbsent(file, () {
+            final existing = defaultHits.remove(file)!;
+            final hits = <int, int>{};
+            final existingDetails = existing.lines?.details;
+            if (existingDetails != null) {
+              final len = existingDetails.length;
+              for (var i = 0; i < len; i++) {
+                final d = existingDetails[i];
+                if (d.line != null) {
+                  hits[d.line!] = (hits[d.line!] ?? 0) + (d.hit ?? 0);
+                }
+              }
+            }
+            return hits;
+          });
+
+          final incomingDetails = record.lines?.details;
+          if (incomingDetails != null) {
+            final len = incomingDetails.length;
+            for (var i = 0; i < len; i++) {
+              final d = incomingDetails[i];
+              if (d.line != null) {
+                lineHits[d.line!] = (lineHits[d.line!] ?? 0) + (d.hit ?? 0);
+              }
             }
           }
-          for (final d in incomingDetails) {
-            if (d.line != null) {
-              lineHits[d.line!] = (lineHits[d.line!] ?? 0) + (d.hit ?? 0);
-            }
-          }
-          merged[file] = _createRecord(file, lineHits);
         }
       }
     }
-    return merged.values.toList();
+
+    final result = defaultHits.values.toList();
+    for (final entry in mergedHits.entries) {
+      result.add(_createRecord(entry.key, entry.value));
+    }
+    return result;
   }
 
   Future<void> _parseJsonCoverageFile(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cover
 description: A simple and efficient tool for comprehensive code coverage analysis.
-version: 0.8.0
+version: 0.8.1
 repository: https://github.com/aosorio-avilez/cover
 
 environment:


### PR DESCRIPTION
# Description
This PR significantly reduces the memory footprint and CPU overhead of the CLI when merging multiple `lcov.info` files together (e.g. combining unit test and integration test coverage).

Previously, the `CoverageService._mergeRecords` method would create and discard thousands of temporary `Record` and `Lines` objects for every overlapping file it encountered during the merge process. 

This update introduces a **lazy merge strategy**. The CLI now intelligently accumulates the line hits into a lightweight map and defers the creation of the final, memory-heavy coverage objects until all files have been fully processed. The result is a much leaner, faster execution, especially on large monorepos with multiple testing targets.

Fixes # (Add issue number here)

## What type of change?

- [ ] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash

---
**Commit Message:**
`perf(service): optimize memory footprint when merging multiple coverage files`