### PR TITLE
feat(commands): add --file-min-coverage flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0
+
+- **Feat**: Added `--file-min-coverage` (abbr: `-c`) option to the `check` command to enforce a minimum coverage percentage on individual files.
+
 ## 0.8.2
 
 - **Fix**: Prevent crash when parsing directories containing non-coverage JSON or malformed files, and support combined parsing of JSON and LCOV info files.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ $ cover check
 # Enforce minimum coverage and show missing lines
 $ cover check --min-coverage 90 --show-uncovered
 
+# Enforce minimum individual file coverage
+$ cover check --file-min-coverage 80
+
 # Ignore generated files and exclude specific paths
 $ cover check --exclude-generated --excluded-paths "lib/generated, lib/src/legacy"
 
@@ -59,6 +62,7 @@ $ cover check --baseline coverage/lcov.base.info
 | :--- | :--- | :--- | :--- |
 | `--path` | `-p` | Path to the `lcov.info` file | `coverage/lcov.info` |
 | `--min-coverage` | `-m` | Minimum required coverage percentage | `100.0` |
+| `--file-min-coverage` | `-c` | Enforce minimum coverage on individual files | `null` |
 | `--show-uncovered`| `-u` | Displays line numbers for missing coverage | `false` |
 | `--exclude-generated`| | Ignores `.g.dart`, `.freezed.dart`, etc. | `false` |
 | `--excluded-paths`| `-e` | Comma-separated paths to exclude | `""` |

--- a/lib/src/commands/check_coverage_command.dart
+++ b/lib/src/commands/check_coverage_command.dart
@@ -86,6 +86,7 @@ class CheckCoverageCommand extends Command<int> {
       );
 
       final githubAnnotations = getGitHubAnnotationsArgument();
+      final fileMinCoverage = getFileMinCoverageArgument();
 
       _displayResult(
         result,
@@ -93,6 +94,7 @@ class CheckCoverageCommand extends Command<int> {
         isMarkdown: isMarkdown,
         githubAnnotations: githubAnnotations,
         minCoverage: minCoverage,
+        fileMinCoverage: fileMinCoverage,
         excludePaths: excludePaths,
         excludeGenerated: excludeGenerated,
         displayFiles: displayFiles,
@@ -104,7 +106,17 @@ class CheckCoverageCommand extends Command<int> {
       final passedBaseline = result.baselineCoverage == null ||
           result.coverage >= result.baselineCoverage!;
 
-      return passedMinCoverage && passedBaseline
+      var passedFileMinCoverage = true;
+      if (fileMinCoverage != null) {
+        for (final record in result.files) {
+          if (record.coveragePercentage < fileMinCoverage) {
+            passedFileMinCoverage = false;
+            break;
+          }
+        }
+      }
+
+      return passedMinCoverage && passedBaseline && passedFileMinCoverage
           ? ExitCode.success.code
           : ExitCode.fail.code;
       // ignore: avoid_catching_errors
@@ -148,6 +160,7 @@ class CheckCoverageCommand extends Command<int> {
     required bool displayFiles,
     required bool showUncovered,
     required bool failuresOnly,
+    double? fileMinCoverage,
   }) {
     final currentCoverage = result.coverage;
 
@@ -155,6 +168,7 @@ class CheckCoverageCommand extends Command<int> {
       final jsonOutput = const JsonEncoder.withIndent('  ').convert(
         result.toJson(
           minCoverage: minCoverage,
+          fileMinCoverage: fileMinCoverage,
           excludePaths: excludePaths,
           excludeGenerated: excludeGenerated,
           failuresOnly: failuresOnly,
@@ -164,7 +178,7 @@ class CheckCoverageCommand extends Command<int> {
     } else if (githubAnnotations) {
       for (final record in result.files) {
         final annotations =
-            record.toGitHubAnnotations(minCoverage: minCoverage);
+            record.toGitHubAnnotations(minCoverage: fileMinCoverage ?? minCoverage);
         for (final annotation in annotations) {
           console.writeLine(annotation);
         }
@@ -173,6 +187,7 @@ class CheckCoverageCommand extends Command<int> {
       _displayMarkdownResult(
         result,
         minCoverage: minCoverage,
+        fileMinCoverage: fileMinCoverage,
         displayFiles: displayFiles,
         showUncovered: showUncovered,
         failuresOnly: failuresOnly,
@@ -185,13 +200,14 @@ class CheckCoverageCommand extends Command<int> {
         final table = buildCoverageFileTable(showUncovered: showUncovered);
         for (final record in result.files) {
           final percentage = record.coveragePercentage;
-          if (failuresOnly && percentage >= minCoverage) {
+          final threshold = fileMinCoverage ?? minCoverage;
+          if (failuresOnly && percentage >= threshold) {
             continue;
           }
           table.insertRow(
             record.toRow(
               showUncovered: showUncovered,
-              minCoverage: minCoverage,
+              minCoverage: threshold,
               percentage: percentage,
             ),
           );
@@ -203,6 +219,12 @@ class CheckCoverageCommand extends Command<int> {
       console
         ..writeLine('Minimum coverage: $greenColor$minCoverage%\x1B[0m')
         ..resetColorAttributes();
+
+      if (fileMinCoverage != null) {
+        console
+          ..writeLine('Minimum file coverage: $greenColor$fileMinCoverage%\x1B[0m')
+          ..resetColorAttributes();
+      }
 
       if (result.baselineCoverage != null) {
         final baseline = result.baselineCoverage!;
@@ -230,6 +252,7 @@ class CheckCoverageCommand extends Command<int> {
     required bool displayFiles,
     required bool showUncovered,
     required bool failuresOnly,
+    double? fileMinCoverage,
   }) {
     final currentCoverage = result.coverage;
     final emoji = currentCoverage.getCoverageEmoji(minCoverage: minCoverage);
@@ -243,8 +266,12 @@ class CheckCoverageCommand extends Command<int> {
       ..writeln()
       ..writeln('- **Total Coverage:** $currentCoverage%')
       ..writeln('- **Progress:** `$progressBar`')
-      ..writeln('- **Minimum Required:** $minCoverage%')
-      ..writeln();
+      ..writeln('- **Minimum Required:** $minCoverage%');
+
+    if (fileMinCoverage != null) {
+      buffer.writeln('- **Minimum File Required:** $fileMinCoverage%');
+    }
+    buffer.writeln();
 
     if (result.baselineCoverage != null) {
       final baseline = result.baselineCoverage!;
@@ -281,14 +308,15 @@ class CheckCoverageCommand extends Command<int> {
 
       for (final record in result.files) {
         final percentage = record.coveragePercentage;
-        if (failuresOnly && percentage >= minCoverage) {
+        final threshold = fileMinCoverage ?? minCoverage;
+        if (failuresOnly && percentage >= threshold) {
           continue;
         }
 
         buffer.writeln(
           record.toMarkdownRow(
             showUncovered: showUncovered,
-            minCoverage: minCoverage,
+            minCoverage: threshold,
             percentage: percentage,
           ),
         );
@@ -412,5 +440,29 @@ class CheckCoverageCommand extends Command<int> {
   bool getFailuresOnlyArgument() {
     return globalResults?[failuresOnlyArgumentName] as bool? ??
         defaultFailuresOnly;
+  }
+
+  double? getFileMinCoverageArgument() {
+    final fileMinCoverageArg =
+        globalResults?[fileMinCoverageArgumentName] as String?;
+
+    if (fileMinCoverageArg == null || fileMinCoverageArg.isEmpty) {
+      return null;
+    }
+
+    final fileMinCoverage = double.tryParse(fileMinCoverageArg);
+
+    if (fileMinCoverage == null ||
+        fileMinCoverage.isNaN ||
+        fileMinCoverage < 0 ||
+        fileMinCoverage > 100) {
+      throw UsageException(
+        'Invalid value for --$fileMinCoverageArgumentName. '
+            'Expected a number between 0 and 100.',
+        '--$fileMinCoverageArgumentName $fileMinCoverageArg',
+      );
+    }
+
+    return fileMinCoverage;
   }
 }

--- a/lib/src/cover_command_runner.dart
+++ b/lib/src/cover_command_runner.dart
@@ -28,6 +28,9 @@ const failuresOnlyArgumentName = 'failures-only';
 const defaultFailuresOnly = false;
 const failuresOnlyHelp =
     'Filter the report to show only files failing the coverage threshold.';
+const fileMinCoverageArgumentName = 'file-min-coverage';
+const fileMinCoverageHelp =
+    'Enforce a minimum coverage percentage for individual files.';
 
 class CoverCommandRunner extends CompletionCommandRunner<int> {
   CoverCommandRunner({Console? console, CoverageService? service})
@@ -102,6 +105,11 @@ class CoverCommandRunner extends CompletionCommandRunner<int> {
         abbr: 'f',
         help: failuresOnlyHelp,
         negatable: false,
+      )
+      ..addOption(
+        fileMinCoverageArgumentName,
+        abbr: 'c',
+        help: fileMinCoverageHelp,
       );
 
     addCommand(CheckCoverageCommand(_console, service: coverageService));

--- a/lib/src/models/coverage_result.dart
+++ b/lib/src/models/coverage_result.dart
@@ -15,6 +15,7 @@ class CoverageResult {
 
   Map<String, dynamic> toJson({
     required double minCoverage,
+    double? fileMinCoverage,
     List<String> excludePaths = const [],
     bool excludeGenerated = false,
     bool failuresOnly = false,
@@ -23,17 +24,30 @@ class CoverageResult {
         ? (coverage - baselineCoverage!).roundToDoubleWithPrecision(2)
         : null;
 
+    final threshold = fileMinCoverage ?? minCoverage;
     final filesToSerialize = failuresOnly
-        ? files.where((f) => f.coveragePercentage < minCoverage).toList()
+        ? files.where((f) => f.coveragePercentage < threshold).toList()
         : files;
+
+    var passedFileMinCoverage = true;
+    if (fileMinCoverage != null) {
+      for (final file in files) {
+        if (file.coveragePercentage < fileMinCoverage) {
+          passedFileMinCoverage = false;
+          break;
+        }
+      }
+    }
 
     return {
       'coverage': coverage,
       'min_coverage': minCoverage,
+      if (fileMinCoverage != null) 'file_min_coverage': fileMinCoverage,
       'baseline_coverage': baselineCoverage,
       'delta': delta,
       'passed': coverage >= minCoverage &&
-          (baselineCoverage == null || coverage >= baselineCoverage!),
+          (baselineCoverage == null || coverage >= baselineCoverage!) &&
+          passedFileMinCoverage,
       'timestamp': DateTime.now().toIso8601String(),
       'files_count': files.length,
       'exclude_generated': excludeGenerated,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cover
 description: A simple and efficient tool for comprehensive code coverage analysis.
-version: 0.8.2
+version: 0.9.0
 repository: https://github.com/aosorio-avilez/cover
 
 environment:

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -464,6 +464,8 @@ void main() {
       () async {
         final exitCode = await runner.run([
           'check',
+          '--path',
+          'test/stubs/lcov_complete.info',
           '--file-min-coverage',
           'invalid',
         ]);
@@ -477,8 +479,40 @@ void main() {
       () async {
         final exitCode = await runner.run([
           'check',
+          '--path',
+          'test/stubs/lcov_complete.info',
           '--file-min-coverage',
           '105',
+        ]);
+
+        expect(exitCode, ExitCode.usage.code);
+      },
+    );
+
+    test(
+      'verify check coverage command returns usage error for negative file-min-coverage',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--path',
+          'test/stubs/lcov_complete.info',
+          '--file-min-coverage',
+          '-5',
+        ]);
+
+        expect(exitCode, ExitCode.usage.code);
+      },
+    );
+
+    test(
+      'verify check coverage command returns usage error for NaN file-min-coverage',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--path',
+          'test/stubs/lcov_complete.info',
+          '--file-min-coverage',
+          'NaN',
         ]);
 
         expect(exitCode, ExitCode.usage.code);

--- a/test/src/commands/check_coverage_command_test.dart
+++ b/test/src/commands/check_coverage_command_test.dart
@@ -422,4 +422,117 @@ void main() {
       expect(hasFailing, isTrue);
     },
   );
+
+  group('file-min-coverage tests', () {
+    test(
+      'verify check coverage command fails when a file is below file-min-coverage',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--path',
+          'test/stubs/lcov_incomplete.info', // overall 94.52%
+          '--min-coverage',
+          '90',
+          '--file-min-coverage',
+          '60', // forgot_password_page has 51.85%
+        ]);
+
+        expect(exitCode, ExitCode.fail.code);
+        verify(() => console.writeLine(any(), any())).called(3); // min, min file, current
+      },
+    );
+
+    test(
+      'verify check coverage command succeeds when all files are above file-min-coverage',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--path',
+          'test/stubs/lcov_incomplete.info', // overall 94.52%
+          '--min-coverage',
+          '90',
+          '--file-min-coverage',
+          '50', // lowest is forgot_password_page at 51.85%
+        ]);
+
+        expect(exitCode, ExitCode.success.code);
+      },
+    );
+
+    test(
+      'verify check coverage command returns usage error for invalid file-min-coverage',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--file-min-coverage',
+          'invalid',
+        ]);
+
+        expect(exitCode, ExitCode.usage.code);
+      },
+    );
+
+    test(
+      'verify check coverage command returns usage error for out-of-range file-min-coverage',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--file-min-coverage',
+          '105',
+        ]);
+
+        expect(exitCode, ExitCode.usage.code);
+      },
+    );
+
+    test(
+      'verify check coverage command JSON includes file_min_coverage state',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--path',
+          'test/stubs/lcov_incomplete.info',
+          '--json',
+          '--min-coverage',
+          '90',
+          '--file-min-coverage',
+          '50',
+        ]);
+
+        expect(exitCode, ExitCode.success.code);
+        final captured =
+            verify(() => console.writeLine(captureAny(), any())).captured;
+        final jsonOutput = captured.first as String;
+        final decoded = jsonDecode(jsonOutput) as Map<String, dynamic>;
+
+        expect(decoded['file_min_coverage'], 50.0);
+        expect(decoded['passed'], isTrue);
+      },
+    );
+
+    test(
+      'verify check coverage command JSON fails passed state when below file_min_coverage',
+      () async {
+        final exitCode = await runner.run([
+          'check',
+          '--path',
+          'test/stubs/lcov_incomplete.info',
+          '--json',
+          '--min-coverage',
+          '90',
+          '--file-min-coverage',
+          '60',
+        ]);
+
+        expect(exitCode, ExitCode.fail.code);
+        final captured =
+            verify(() => console.writeLine(captureAny(), any())).captured;
+        final jsonOutput = captured.first as String;
+        final decoded = jsonDecode(jsonOutput) as Map<String, dynamic>;
+
+        expect(decoded['file_min_coverage'], 60.0);
+        expect(decoded['passed'], isFalse);
+      },
+    );
+  });
 }

--- a/test/src/commands/markdown_report_test.dart
+++ b/test/src/commands/markdown_report_test.dart
@@ -140,5 +140,24 @@ void main() {
       expect(output, contains('- **Baseline:** 100.0%'));
       expect(output, contains('- **Delta:** -5.48%'));
     });
+
+    test('verify markdown output with --markdown and --file-min-coverage',
+        () async {
+      final exitCode = await runner.run([
+        'check',
+        '--path',
+        'test/stubs/lcov_incomplete.info',
+        '--markdown',
+        '--file-min-coverage',
+        '80',
+      ]);
+
+      expect(exitCode, ExitCode.fail.code);
+
+      final captured = verify(() => console.write(captureAny())).captured;
+      final output = captured.join('\n');
+
+      expect(output, contains('- **Minimum File Required:** 80.0%'));
+    });
   });
 }


### PR DESCRIPTION
This PR introduces the `--file-min-coverage` (abbreviation `-c`) option for the `check` command to enforce a minimum coverage percentage on individual files, returning a failure exit code if any single file falls below the threshold.

## Description
Enforcing a minimum average code coverage threshold (e.g., 80%) for the whole project is a standard practice, but it can hide untested files if other files have 100% coverage. 

With `--file-min-coverage`, developers and CI/CD pipelines can establish a second quality gate ensuring that **no individual file falls below a specific threshold** (e.g., 50%), even if the overall project meets the required average code coverage target.

### What value does it bring?
* **Stricter CI/CD Quality Gates**: Prevents files with zero or critically low coverage from being merged.
* **Independent Thresholds**: Enables custom individual file thresholds distinct from the global min-coverage (e.g. `cover check --min-coverage 90 --file-min-coverage 75`).
* **Visual Diagnostics**: Displays file-level threshold failures in terminal tables, Markdown reports, JSON metrics, and GitHub Actions annotations.

This fixes #87 (Enforce coverage limits per individual files).

## What type of change?

- [x] ✨ New feature (change which adds functionality)
- [ ] 🛠️ Bug fix (change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Trash